### PR TITLE
Add an aws lambda event struct generator + generated event structs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,5 +2,6 @@
 members = [
   "aws_lambda_bundle",
   "aws_lambda_codegen",
+  "aws_lambda_events",
   "aws_lambda_runtime",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = [
+  "aws_lambda_bundle",
+  "aws_lambda_codegen",
   "aws_lambda_runtime",
-  "aws_lambda_bundle"
 ]

--- a/aws_lambda_codegen/Cargo.toml
+++ b/aws_lambda_codegen/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "aws_lambda_codegen"
+version = "0.1.0"
+authors = ["Christian Legnitto <christian@legnitto.com>"]
+publish = false
+
+[dependencies]
+quicli = "0.2"
+glob = "0.2"
+go_to_rust = { path = "./go_to_rust" }

--- a/aws_lambda_codegen/go_to_rust/Cargo.toml
+++ b/aws_lambda_codegen/go_to_rust/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "go_to_rust"
+version = "0.1.0"
+authors = ["Christian Legnitto <christian@legnitto.com>"]
+build = "build.rs"
+publish = false
+
+[[test]]
+name = "integration"
+harness = false
+
+[dependencies]
+log = "0.4"
+pest = "^1.0"
+pest_derive = "^1.0"
+# Needed to pick up this PR: https://github.com/carllerche/codegen/pull/6
+codegen = { git = "https://github.com/LegNeato/codegen.git", branch = "issue-3-and-4-field-documentation-annotation"}
+failure = "0.1.1"
+heck = "0.3.0"
+#rustfmt-nightly = "0.6.0"
+
+[dev-dependencies]
+rustc-test ="0.3"
+glob = "0.2"
+env_logger = "0.5.9"

--- a/aws_lambda_codegen/go_to_rust/build.rs
+++ b/aws_lambda_codegen/go_to_rust/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("cargo:rerun-if-changed=./src/aws_go_events.pest");
+}

--- a/aws_lambda_codegen/go_to_rust/src/aws_go_events.pest
+++ b/aws_lambda_codegen/go_to_rust/src/aws_go_events.pest
@@ -1,0 +1,73 @@
+newline = _{ "\n" | "\r\n" | eoi }
+whitespace = _{ " " | "\t" }
+whitespace_or_newline = _{ whitespace | newline }
+comment_line = @{ whitespace* ~ any_comment ~ whitespace* }
+any_comment = { block_comment | "//" ~ (!newline ~ any)* }
+block_comment = _{ "/*" ~ (block_comment | !"*/" ~ any)* ~ "*/" }
+
+alpha = _{ 'a'..'z' | 'A'..'Z' }
+digit = _{ '0'..'9' }
+non_alpha = _{ "_" | "-" }
+
+ident = { (alpha | digit | non_alpha)+ }
+ident_list = _{ !digit ~ ident ~ (" " ~ ident)+ }
+
+// Built-in types --------------------------------------------------------------
+// Primitives
+boolean = { "bool" }
+byte = { "byte" }
+int = { "int" | "int64" }
+uint = { "uint" | "uint64" }
+float = { "float" | "float" }
+string = { "string" }
+primitive = { boolean | byte | int | uint | float | string }
+
+// Non-primitives
+interface = { "interface" ~ "{" ~ "}"}
+array = { "[]" ~ (interface | primitive | map | ident) }
+
+// Collections. This isn't 100% correct but whatever.
+key_type = { primitive }
+value_type = { interface | primitive | array | ident }
+map = { "map[" ~ key_type ~ "]" ~ value_type }
+
+non_primitive = { map | array | interface }
+
+package_ident = ${ ident ~ ("." ~ ident)+ }
+
+// Structure types -------------------------------------------------------------
+json_name = { (digit | alpha | non_alpha | "." )+ }
+omit_empty = { "," ~ "omitempty" }
+json_meta = _{ json_name ~ omit_empty? }
+json_mapping = { "`json:\"" ~ json_meta ~ "\"`" ~ whitespace* ~ any_comment?  }
+
+struct_field_type = { interface | primitive | array | map | package_ident | ident }
+
+struct_field = ${ ident ~ whitespace+ ~ "*"? ~ struct_field_type ~ whitespace* ~ json_mapping? }
+
+struct_fields = { struct_field ~ (newline+ ~ struct_field)* }
+
+struct_name = { ident }
+struct_preamble = ${ "type" ~ whitespace+ ~ struct_name ~ whitespace+ ~ "struct" }
+
+doc_comment = { any_comment ~ newline }
+struct_def = { doc_comment* ~ struct_preamble ~ "{" ~ whitespace_or_newline* ~ struct_fields? ~ whitespace_or_newline* ~ "}" }
+
+// Package types ---------------------------------------------------------------
+package_kw = _{ "package" }
+package_def = { package_kw ~ ident }
+
+// Import types ----------------------------------------------------------------
+import_kw = _{ "import" }
+package_name = { (alpha | digit | non_alpha | "/")+ }
+import_package = ${ "\"" ~ package_name ~ "\"" }
+import = { import_kw ~ import_package  }
+import_multiple = ${ import_kw ~ whitespace+ ~ "(" ~ (whitespace_or_newline* ~ import_package ~ whitespace_or_newline*)+ ~ ")" }
+
+// Type alias types ------------------------------------------------------------
+type_kw = _{ "type" }
+type_alias = { type_kw ~ ident ~ whitespace+ ~ package_ident }
+
+// Top-level type --------------------------------------------------------------
+all = _{ package_def | import | import_multiple | struct_def | type_alias | any_comment }
+aws_go_events = _{  (newline? ~ newline? ~ all ~ newline)+  }

--- a/aws_lambda_codegen/go_to_rust/src/lib.rs
+++ b/aws_lambda_codegen/go_to_rust/src/lib.rs
@@ -1,0 +1,828 @@
+#[macro_use]
+extern crate log;
+#[cfg(test)]
+#[macro_use]
+extern crate pest;
+#[cfg(not(test))]
+extern crate pest;
+#[macro_use]
+extern crate pest_derive;
+extern crate codegen;
+extern crate failure;
+extern crate heck;
+// extern crate rustfmt_nightly;
+
+use codegen::{Field, Scope, Struct};
+use failure::Error;
+use heck::SnakeCase;
+use pest::iterators::Pairs;
+use pest::Parser;
+use std::boxed::Box;
+use std::collections::HashSet;
+use std::fmt;
+use std::fs::File;
+use std::io::prelude::*;
+use std::path::PathBuf;
+
+#[derive(Parser)]
+#[grammar = "aws_go_events.pest"]
+pub struct AwsGoEventsParser;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct GoCode(String);
+impl fmt::Display for GoCode {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+#[derive(Debug, Clone, PartialEq)]
+pub struct RustCode(String);
+impl RustCode {
+    pub fn new(text: String) -> Self {
+        RustCode(text)
+    }
+    pub fn as_bytes(&self) -> &[u8] {
+        self.0.as_bytes()
+    }
+}
+impl fmt::Display for RustCode {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+pub fn parse_go_file(path: &PathBuf) -> Result<(GoCode, RustCode), Error> {
+    debug!("Parsing path: {:?}", &path.display());
+
+    // Read the go code.
+    let mut f = File::open(path)?;
+    let mut go_code = String::new();
+    f.read_to_string(&mut go_code)?;
+    debug!("\n{}\n", go_code);
+
+    // parse the go code into rust code.
+    Ok(parse_go_string(go_code)?)
+}
+
+pub fn parse_go_string(go_source: String) -> Result<(GoCode, RustCode), Error> {
+    let source = go_source.clone();
+
+    let pairs = AwsGoEventsParser::parse(Rule::aws_go_events, &source.trim())
+        .unwrap_or_else(|e| panic!("{}", e));
+
+    let mut scope = Scope::new();
+
+    for pair in pairs {
+        match pair.as_rule() {
+            Rule::struct_def => {
+                let (parsed_struct, required_libraries) = parse_struct(pair.into_inner())?;
+                scope.push_struct(parsed_struct);
+
+                // Stable sort the libraries.
+                let mut ordered_libs: Vec<String> = required_libraries.iter().cloned().collect();
+                ordered_libs.sort();
+
+                // Import required libraries.
+                for lib in ordered_libs {
+                    // Lame.
+                    let parts: Vec<&str> = lib.rsplitn(2, "::").collect();
+                    scope.import(parts[1], parts[0]);
+                }
+            }
+            // Skip some things for now.
+            Rule::any_comment | Rule::package_def | Rule::import | Rule::import_multiple => {
+                debug!("Skipping: {}", pair.clone().into_span().as_str());
+                ()
+            }
+            _ => {
+                panic!(
+                    "Unexpected item at top-level:\n{:?}\n{}",
+                    pair.clone(),
+                    pair.clone().into_span().as_str()
+                );
+            }
+        }
+    }
+
+    debug!("{}", &scope.to_string());
+
+    /*
+    let formatted_code =
+        rustfmt_nightly::format_code_block(&scope.to_string(), &rustfmt_nightly::Config::default())
+            .expect("formatted code");
+    */
+
+    Ok((GoCode(go_source), RustCode(scope.to_string())))
+}
+
+#[derive(Debug, Clone)]
+struct FieldDef {
+    name: String,
+    json_name: Option<String>,
+    comment: Option<String>,
+    omit_empty: bool,
+    go_type: GoType,
+}
+
+fn parse_comment(c: &str) -> String {
+    c.replacen("//", "", 1).trim().to_string()
+}
+
+fn parse_struct(pairs: Pairs<Rule>) -> Result<(codegen::Struct, HashSet<String>), Error> {
+    debug!("Parsing struct");
+    let mut name: Option<String> = None;
+    let mut fields: Vec<FieldDef> = Vec::new();
+    let mut comments: Vec<String> = Vec::new();
+
+    for pair in pairs {
+        let span = pair.clone().into_span();
+        match pair.as_rule() {
+            Rule::doc_comment => {
+                comments.push(parse_comment(span.as_str()));
+            }
+            Rule::struct_preamble => {
+                name = Some(parse_struct_preamble(pair.into_inner())?);
+            }
+            Rule::struct_fields => {
+                fields = parse_struct_fields(pair.into_inner())?;
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    let struct_name = name.expect("parsed name");
+
+    let mut rust_struct = Struct::new(&struct_name);
+
+    // Make it public.
+    rust_struct.vis("pub");
+
+    // Add some derives.
+    rust_struct.derive("Debug");
+    rust_struct.derive("Clone");
+    rust_struct.derive("Deserialize");
+    rust_struct.derive("Serialize");
+
+    if !comments.is_empty() {
+        let annotated_comments: Vec<String> = comments
+            .iter_mut()
+            .map(|x| x.replace(&struct_name, &format!("`{}`", &struct_name)))
+            .collect();
+        rust_struct.doc(&annotated_comments.join("\n"));
+    }
+
+    let mut libraries: HashSet<String> = HashSet::new();
+
+    for f in fields {
+        // Translate the name.
+        let member_name = mangle(&f.name.to_snake_case());
+
+        // Extract the code and the libraries from the result.
+        let rust_data = translate_go_type_to_rust_type(f.go_type)?;
+        for lib in rust_data.libraries.iter() {
+            libraries.insert(lib.clone());
+        }
+        let mut rust_type = rust_data.value;
+
+        // Make fields optional if they are optional in the json.
+        if f.omit_empty {
+            rust_type = format!("Option<{}>", rust_type);
+        }
+
+        let mut field = Field::new(&member_name, &rust_type);
+
+        // Fields are public.
+        field.vis("pub");
+
+        if let Some(c) = f.comment {
+            field.doc(&c);
+        }
+        if let Some(rename) = f.json_name {
+            if rename != member_name {
+                field.annotation(vec![&format!("#[serde(rename = \"{}\")]", rename)]);
+            }
+        }
+        rust_struct.push_field(field);
+    }
+
+    Ok((rust_struct, libraries))
+}
+
+fn parse_struct_preamble(pairs: Pairs<Rule>) -> Result<String, Error> {
+    debug!("Parsing struct preamble");
+    let mut name: Option<String> = None;
+
+    for pair in pairs {
+        let span = pair.clone().into_span();
+        match pair.as_rule() {
+            Rule::struct_name => {
+                name = Some(span.as_str().to_string());
+            }
+            _ => unimplemented!(),
+        }
+    }
+
+    Ok(name.expect("structs always have a name"))
+}
+
+fn parse_struct_fields(pairs: Pairs<Rule>) -> Result<Vec<FieldDef>, Error> {
+    debug!("Parsing struct fields");
+
+    let mut fields: Vec<FieldDef> = Vec::new();
+
+    for pair in pairs {
+        match pair.as_rule() {
+            Rule::struct_field => fields.push(parse_struct_field(pair.into_inner())?),
+            _ => unimplemented!(),
+        }
+    }
+
+    Ok(fields)
+}
+
+fn parse_struct_field(pairs: Pairs<Rule>) -> Result<FieldDef, Error> {
+    debug!("Parsing struct field");
+    let mut name: Option<String> = None;
+    let mut json: Option<JsonMapping> = None;
+    let mut go_type: Option<GoType> = None;
+
+    for pair in pairs {
+        debug!("{:?}", pair);
+        let span = pair.clone().into_span();
+        match pair.as_rule() {
+            Rule::ident => name = Some(mangle(span.as_str())),
+            Rule::json_mapping => json = Some(parse_json_mapping(pair.into_inner())?),
+            Rule::struct_field_type => go_type = Some(parse_go_type(pair.into_inner())?),
+            _ => unimplemented!(),
+        }
+    }
+
+    let json_name = if let Some(j) = json.clone() {
+        Some(j.name)
+    } else {
+        None
+    };
+
+    let omit_empty = if let Some(j) = json.clone() {
+        j.omit_empty
+    } else {
+        false
+    };
+
+    let comment =
+        if let Some(j) = json { j.comment } else { None };
+
+    Ok(FieldDef {
+        name: name.expect("fields have names"),
+        json_name,
+        comment,
+        omit_empty,
+        go_type: go_type.expect("fields have types"),
+    })
+}
+
+#[derive(Debug, Clone)]
+struct JsonMapping {
+    name: String,
+    comment: Option<String>,
+    omit_empty: bool,
+}
+
+fn parse_json_mapping(pairs: Pairs<Rule>) -> Result<JsonMapping, Error> {
+    debug!("Parsing json mapping");
+    let mut name: Option<String> = None;
+    let mut comment: Option<String> = None;
+    let mut omit_empty = false;
+
+    for pair in pairs {
+        debug!("{:?}", pair);
+        let span = pair.clone().into_span();
+        match pair.as_rule() {
+            Rule::json_name => name = Some(span.as_str().to_string()),
+            Rule::any_comment => comment = Some(parse_comment(span.as_str())),
+            Rule::omit_empty => omit_empty = true,
+            _ => unimplemented!(),
+        }
+    }
+
+    Ok(JsonMapping {
+        name: name.expect("json mappings always have a name"),
+        comment,
+        omit_empty,
+    })
+}
+
+#[derive(Debug, Clone)]
+enum GoType {
+    StringType,
+    IntType,
+    UnsignedIntType,
+    FloatType,
+    BoolType,
+    ByteType,
+    UserDefined(String),
+    ArrayType(Box<GoType>),
+    MapType(Box<GoType>, Box<GoType>),
+    InterfaceType,
+    TimeType,
+    JsonRawType,
+}
+
+struct RustType {
+    libraries: HashSet<String>,
+    value: String,
+}
+
+fn parse_go_type(pairs: Pairs<Rule>) -> Result<GoType, Error> {
+    debug!("Parsing go type");
+    let mut go_type: Option<GoType> = None;
+
+    for pair in pairs {
+        debug!("{:?}", pair);
+        let value = pair.clone().into_span().as_str();
+        go_type = match pair.as_rule() {
+            Rule::array => Some(parse_go_type_array(pair.into_inner())?),
+            Rule::primitive => Some(parse_go_type_primitive(value)?),
+            Rule::ident => Some(GoType::UserDefined(value.to_string())),
+            Rule::package_ident => Some(parse_go_package_ident(value)?),
+            Rule::map => Some(parse_go_type_map(pair.into_inner())?),
+            Rule::interface => Some(parse_go_type_interface(value)?),
+            _ => unimplemented!(),
+        };
+    }
+
+    Ok(go_type.expect("parsing go type"))
+}
+
+fn parse_go_type_array(pairs: Pairs<Rule>) -> Result<GoType, Error> {
+    debug!("Parsing go array");
+    let mut go_type: Option<GoType> = None;
+
+    for pair in pairs {
+        debug!("{:?}", pair);
+        let value = pair.clone().into_span().as_str();
+        go_type = match pair.as_rule() {
+            Rule::primitive => Some(GoType::ArrayType(Box::new(parse_go_type_primitive(value)?))),
+            Rule::ident => Some(GoType::ArrayType(Box::new(GoType::UserDefined(
+                value.to_string(),
+            )))),
+            Rule::map => Some(GoType::ArrayType(Box::new(parse_go_type_map(
+                pair.into_inner(),
+            )?))),
+            _ => unimplemented!(),
+        };
+    }
+
+    Ok(go_type.expect("parsing go array"))
+}
+
+fn parse_go_type_map(pairs: Pairs<Rule>) -> Result<GoType, Error> {
+    debug!("Parsing go map");
+    let mut key_type: Option<GoType> = None;
+    let mut value_type: Option<GoType> = None;
+
+    for pair in pairs {
+        debug!("{:?}", pair);
+        let value = pair.clone().into_span().as_str();
+        match pair.as_rule() {
+            Rule::key_type => key_type = Some(parse_go_type_primitive(value)?),
+            Rule::value_type => value_type = Some(parse_go_type(pair.into_inner())?),
+            _ => unimplemented!(),
+        };
+    }
+
+    Ok(GoType::MapType(
+        Box::new(key_type.expect("parsing map key")),
+        Box::new(value_type.expect("parsing map value")),
+    ))
+}
+
+fn parse_go_type_interface(_t: &str) -> Result<GoType, Error> {
+    // For now we don't parse.
+    Ok(GoType::InterfaceType)
+}
+
+fn parse_go_type_primitive(t: &str) -> Result<GoType, Error> {
+    match t {
+        "string" => Ok(GoType::StringType),
+        "int" | "int32" | "int64" => Ok(GoType::IntType),
+        "uint" | "uint32" | "uint64" => Ok(GoType::UnsignedIntType),
+        "float" | "float32" | "float64" => Ok(GoType::FloatType),
+        "bool" => Ok(GoType::BoolType),
+        "byte" => Ok(GoType::ByteType),
+        _ => unimplemented!("missing go type primitive"),
+    }
+}
+
+fn parse_go_package_ident(t: &str) -> Result<GoType, Error> {
+    match t {
+        "time.Time" => Ok(GoType::TimeType),
+        "json.RawMessage" => Ok(GoType::JsonRawType),
+        _ => unimplemented!("missing go package ident mapping"),
+    }
+}
+
+fn mangle(s: &str) -> String {
+    // TODO: Add more keywords.
+    match s {
+        "type" => "type_".to_string(),
+        _ => s.to_string(),
+    }
+}
+
+fn make_rust_type_with_no_libraries(value: &str) -> RustType {
+    RustType {
+        value: value.to_string(),
+        libraries: HashSet::new(),
+    }
+}
+
+fn translate_go_type_to_rust_type(go_type: GoType) -> Result<RustType, Error> {
+    let rust_type = match &go_type {
+        GoType::StringType => make_rust_type_with_no_libraries("String"),
+        GoType::BoolType => make_rust_type_with_no_libraries("bool"),
+        GoType::ByteType => make_rust_type_with_no_libraries("u8"),
+        GoType::IntType => make_rust_type_with_no_libraries("i64"),
+        GoType::UnsignedIntType => make_rust_type_with_no_libraries("u64"),
+        GoType::FloatType => make_rust_type_with_no_libraries("f64"),
+        GoType::UserDefined(x) => make_rust_type_with_no_libraries(x),
+        GoType::ArrayType(x) => {
+            let i = translate_go_type_to_rust_type(*x.clone())?;
+            RustType {
+                value: format!("Vec<{}>", i.value),
+                libraries: i.libraries,
+            }
+        }
+        GoType::MapType(k, v) => {
+            let key_data = translate_go_type_to_rust_type(*k.clone())?;
+            let value_data = translate_go_type_to_rust_type(*v.clone())?;
+
+            let key_libs: HashSet<String> = key_data.libraries.iter().cloned().collect();
+            let value_libs: HashSet<String> = value_data.libraries.iter().cloned().collect();
+
+            let mut libraries: HashSet<String> = key_libs.union(&value_libs).cloned().collect();
+            libraries.insert("std::collections::HashMap".to_string());
+
+            RustType {
+                value: format!("HashMap<{}, {}>", key_data.value, value_data.value),
+                libraries,
+            }
+        }
+        // For now we treat interfaces as a bag of bytes.
+        GoType::InterfaceType => {
+            let mut libraries = HashSet::new();
+            libraries.insert("bytes::Bytes".to_string());
+            RustType {
+                value: "Bytes".to_string(),
+                libraries,
+            }
+        }
+        GoType::JsonRawType => {
+            let mut libraries = HashSet::new();
+            libraries.insert("serde_json::Value".to_string());
+            RustType {
+                value: "Value".to_string(),
+                libraries,
+            }
+        }
+        GoType::TimeType => {
+            let mut libraries = HashSet::new();
+            libraries.insert("chrono::DateTime".to_string());
+            libraries.insert("chrono::Utc".to_string());
+
+            RustType {
+                value: "DateTime<Utc>".to_string(),
+                libraries,
+            }
+        }
+    };
+
+    Ok(rust_type)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    mod primitives {
+        use super::*;
+
+        #[test]
+        fn test_parses_array() {
+            parses_to! {
+                parser: AwsGoEventsParser,
+                input: "[]bool",
+                rule: Rule::array,
+                tokens: [
+                    array(0, 6, [
+                        primitive(2, 6, [
+                            boolean(2, 6),
+                        ]),
+                    ]),
+                ]
+            };
+
+            parses_to! {
+                parser: AwsGoEventsParser,
+                input: "[]blah",
+                rule: Rule::array,
+                tokens: [
+                    array(0, 6, [
+                        ident(2, 6),
+                    ]),
+                ]
+            };
+        }
+
+        #[test]
+        fn test_parses_map() {
+            parses_to! {
+                parser: AwsGoEventsParser,
+                input: "map[string]interface{}",
+                rule: Rule::map,
+                tokens: [
+                    map(0, 22, [
+                        key_type(4, 10, [
+                            primitive(4, 10, [
+                                string(4, 10),
+                            ]),
+                        ]),
+                        value_type(11, 22, [
+                            interface(11, 22),
+                        ]),
+                    ]),
+                ]
+            };
+        }
+    }
+
+    mod directives {
+        use super::*;
+
+        #[test]
+        fn test_parses_package_def() {
+            parses_to! {
+                parser: AwsGoEventsParser,
+                input: "package foo",
+                rule: Rule::package_def,
+                tokens: [
+                    package_def(0, 11, [
+                        ident(8, 11),
+                    ]),
+                ]
+            };
+        }
+
+        #[test]
+        fn test_parses_struct_def() {
+            parses_to! {
+                parser: AwsGoEventsParser,
+                input: "type MyFoo struct {}",
+                rule: Rule::struct_def,
+                tokens: [
+                    struct_def(0, 20, [
+                        struct_preamble(0, 17, [
+                            struct_name(5, 10, [
+                                ident(5, 10),
+                            ]),
+                        ]),
+                    ]),
+                ]
+            };
+
+            parses_to! {
+                parser: AwsGoEventsParser,
+                input: "type MyFoo struct { foo string }",
+                rule: Rule::struct_def,
+                tokens: [
+                    struct_def(0, 32, [
+                        struct_preamble(0, 17, [
+                            struct_name(5, 10, [
+                                ident(5, 10),
+                            ]),
+                        ]),
+                        struct_fields(20, 31, [
+                            struct_field(20, 31, [
+                                ident(20, 23),
+                                struct_field_type(24, 30, [
+                                    primitive(24, 30, [
+                                        string(24, 30)
+                                    ]),
+                                ]),
+                            ]),
+                        ]),
+                    ]),
+                ]
+            };
+
+            parses_to! {
+                parser: AwsGoEventsParser,
+                input: r#"type MyFoo struct {
+                  foo string
+                  bar int
+                }"#,
+                rule: Rule::struct_def,
+                tokens: [
+                    struct_def(0, 92, [
+                        struct_preamble(0, 17, [
+                            struct_name(5, 10, [
+                                ident(5, 10),
+                            ]),
+                        ]),
+                        struct_fields(38, 74, [
+                            struct_field(38, 48, [
+                                ident(38, 41),
+                                struct_field_type(42, 48, [
+                                    primitive(42, 48, [
+                                        string(42, 48)
+                                    ]),
+                                ]),
+                            ]),
+                            struct_field(67, 74, [
+                                ident(67, 70),
+                                struct_field_type(71, 74, [
+                                    primitive(71, 74, [
+                                        int(71, 74)
+                                    ]),
+                                ]),
+                            ]),
+                        ]),
+                    ]),
+                ]
+            };
+        }
+
+        #[test]
+        fn test_parses_struct_field() {
+            parses_to! {
+                parser: AwsGoEventsParser,
+                input: "EventVersion string",
+                rule: Rule::struct_field,
+                tokens: [
+                    struct_field(0, 19, [
+                        ident(0, 12),
+                        struct_field_type(13, 19, [
+                            primitive(13, 19, [
+                                string(13, 19),
+                            ]),
+                        ]),
+                    ]),
+                ]
+            };
+
+            parses_to! {
+                parser: AwsGoEventsParser,
+                input: "EventVersion bool",
+                rule: Rule::struct_field,
+                tokens: [
+                    struct_field(0, 17, [
+                        ident(0, 12),
+                        struct_field_type(13, 17, [
+                            primitive(13, 17, [
+                                boolean(13, 17),
+                            ]),
+                        ]),
+                    ]),
+                ]
+            };
+
+            parses_to! {
+                parser: AwsGoEventsParser,
+                input: "EventVersion *bool",
+                rule: Rule::struct_field,
+                tokens: [
+                    struct_field(0, 18, [
+                        ident(0, 12),
+                        struct_field_type(14, 18, [
+                            primitive(14, 18, [
+                                boolean(14, 18),
+                            ]),
+                        ]),
+                    ]),
+                ]
+            };
+
+            parses_to! {
+                parser: AwsGoEventsParser,
+                input: "EventVersion MyType",
+                rule: Rule::struct_field,
+                tokens: [
+                    struct_field(0, 19, [
+                        ident(0, 12),
+                        struct_field_type(13, 19, [
+                            ident(13, 19),
+                        ]),
+                    ]),
+                ]
+            };
+        }
+
+        #[test]
+        fn test_parses_json_mapping() {
+            parses_to! {
+                parser: AwsGoEventsParser,
+                input: "`json:\"fooBar\"`",
+                rule: Rule::json_mapping,
+                tokens: [
+                    json_mapping(0, 15, [
+                        json_name(7, 13),
+                    ]),
+                ]
+            };
+
+            parses_to! {
+                parser: AwsGoEventsParser,
+                input: "`json:\"foo-x\"`",
+                rule: Rule::json_mapping,
+                tokens: [
+                    json_mapping(0, 14, [
+                        json_name(7, 12),
+                    ]),
+                ]
+            };
+
+            parses_to! {
+                parser: AwsGoEventsParser,
+                input: "`json:\"foo.x\"`",
+                rule: Rule::json_mapping,
+                tokens: [
+                    json_mapping(0, 14, [
+                        json_name(7, 12),
+                    ]),
+                ]
+            };
+
+            parses_to! {
+                parser: AwsGoEventsParser,
+                input: "`json:\"foo,omitempty\"`",
+                rule: Rule::json_mapping,
+                tokens: [
+                    json_mapping(0, 22, [
+                        json_name(7, 10),
+                        omit_empty(10, 20),
+                    ]),
+                ]
+            };
+
+            parses_to! {
+                parser: AwsGoEventsParser,
+                input: "`json:\"fooBar\"` // whatever",
+                rule: Rule::json_mapping,
+                tokens: [
+                    json_mapping(0, 27, [
+                        json_name(7, 13),
+                        any_comment(16, 27),
+                    ]),
+                ]
+            };
+        }
+
+        #[test]
+        fn test_parses_import() {
+            parses_to! {
+                parser: AwsGoEventsParser,
+                input: "import \"foo\"",
+                rule: Rule::import,
+                tokens: [
+                    import(0, 12, [
+                        import_package(7, 12, [
+                            package_name(8, 11),
+                        ]),
+                    ]),
+                ]
+            };
+
+            parses_to! {
+                parser: AwsGoEventsParser,
+                input: "import \"a/b\"",
+                rule: Rule::import,
+                tokens: [
+                    import(0, 12, [
+                        import_package(7, 12, [
+                            package_name(8, 11),
+                        ]),
+                    ]),
+                ]
+            };
+        }
+
+        #[test]
+        fn test_parses_mutiple_imports() {
+            parses_to! {
+                parser: AwsGoEventsParser,
+                input: "import (\n\"foo\"\n \"bar\"\n)",
+                rule: Rule::import_multiple,
+                tokens: [
+                    import_multiple(0, 23, [
+                        import_package(9, 14, [
+                            package_name(10, 13),
+                        ]),
+                        import_package(16, 21, [
+                            package_name(17, 20),
+                        ]),
+                    ]),
+                ]
+            };
+        }
+    }
+}

--- a/aws_lambda_codegen/go_to_rust/tests/fixtures/annotated_comment/expected.txt
+++ b/aws_lambda_codegen/go_to_rust/tests/fixtures/annotated_comment/expected.txt
@@ -1,0 +1,3 @@
+/// Blah blah `MyCoolThing` blah blah
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct MyCoolThing;

--- a/aws_lambda_codegen/go_to_rust/tests/fixtures/annotated_comment/input.txt
+++ b/aws_lambda_codegen/go_to_rust/tests/fixtures/annotated_comment/input.txt
@@ -1,0 +1,2 @@
+// Blah blah MyCoolThing blah blah
+type MyCoolThing struct {}

--- a/aws_lambda_codegen/go_to_rust/tests/fixtures/multiple_definitions/expected.txt
+++ b/aws_lambda_codegen/go_to_rust/tests/fixtures/multiple_definitions/expected.txt
@@ -1,0 +1,4 @@
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct SimpleEmailEvent {
+    pub blah: i64,
+}

--- a/aws_lambda_codegen/go_to_rust/tests/fixtures/multiple_definitions/input.txt
+++ b/aws_lambda_codegen/go_to_rust/tests/fixtures/multiple_definitions/input.txt
@@ -1,0 +1,11 @@
+package events
+
+import "time"
+
+import (
+  "foo"
+)
+
+type SimpleEmailEvent struct {
+  blah int
+}

--- a/aws_lambda_codegen/go_to_rust/tests/fixtures/omit_empty/expected.txt
+++ b/aws_lambda_codegen/go_to_rust/tests/fixtures/omit_empty/expected.txt
@@ -1,0 +1,5 @@
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct Foo {
+    #[serde(rename = "blah")]
+    pub bar: Option<i64>,
+}

--- a/aws_lambda_codegen/go_to_rust/tests/fixtures/omit_empty/input.txt
+++ b/aws_lambda_codegen/go_to_rust/tests/fixtures/omit_empty/input.txt
@@ -1,0 +1,3 @@
+type Foo struct {
+  bar int `json:"blah,omitempty"`
+}

--- a/aws_lambda_codegen/go_to_rust/tests/fixtures/rename_reserved_keywords/expected.txt
+++ b/aws_lambda_codegen/go_to_rust/tests/fixtures/rename_reserved_keywords/expected.txt
@@ -1,0 +1,4 @@
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct Fake {
+    pub type_: u8,
+}

--- a/aws_lambda_codegen/go_to_rust/tests/fixtures/rename_reserved_keywords/input.txt
+++ b/aws_lambda_codegen/go_to_rust/tests/fixtures/rename_reserved_keywords/input.txt
@@ -1,0 +1,3 @@
+type Fake struct {
+  type byte
+}

--- a/aws_lambda_codegen/go_to_rust/tests/fixtures/struct_members/expected.txt
+++ b/aws_lambda_codegen/go_to_rust/tests/fixtures/struct_members/expected.txt
@@ -1,0 +1,25 @@
+use bytes::Bytes;
+use chrono::{DateTime, Utc};
+use serde_json::Value;
+use std::collections::HashMap;
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct SimpleEmailMessage {
+    #[serde(rename = "commonHeaders")]
+    pub common_headers: SimpleEmailCommonHeaders,
+    pub source: String,
+    pub timestamp: DateTime<Utc>,
+    #[serde(rename = "rawJson")]
+    pub raw: Value,
+    pub destination: Vec<String>,
+    pub headers: Vec<SimpleEmailHeader>,
+    #[serde(rename = "headersTruncated")]
+    pub headers_truncated: bool,
+    #[serde(rename = "messageId")]
+    pub message_id: String,
+    pub resolutions: Vec<HashMap<String, String>>,
+    pub blah: u64,
+    pub whatever: i64,
+    pub detail: HashMap<String, Bytes>,
+    pub data: Vec<u8>,
+}

--- a/aws_lambda_codegen/go_to_rust/tests/fixtures/struct_members/input.txt
+++ b/aws_lambda_codegen/go_to_rust/tests/fixtures/struct_members/input.txt
@@ -1,0 +1,15 @@
+type SimpleEmailMessage struct {
+	CommonHeaders    SimpleEmailCommonHeaders `json:"commonHeaders"`
+	Source           string                   `json:"source"`
+	Timestamp        time.Time                `json:"timestamp"`
+	Raw              json.RawMessage          `json:"rawJson"`
+	Destination      []string                 `json:"destination"`
+	Headers          []SimpleEmailHeader      `json:"headers"`
+	HeadersTruncated bool                     `json:"headersTruncated"`
+	MessageID        string                   `json:"messageId"`
+	Resolutions      []map[string]string      `json:"resolutions"`
+	blah             uint
+	whatever         int
+	Detail           map[string]interface{}   `json:"detail"`
+	Data             []byte                   `json:"data"`
+}

--- a/aws_lambda_codegen/go_to_rust/tests/fixtures/struct_with_comments/expected.txt
+++ b/aws_lambda_codegen/go_to_rust/tests/fixtures/struct_with_comments/expected.txt
@@ -1,0 +1,9 @@
+/// Foo
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct SimpleEmailEvent {
+    /// My cool thing
+    #[serde(rename = "fooBar")]
+    pub records: String,
+    #[serde(rename = "blah")]
+    pub records2: i64,
+}

--- a/aws_lambda_codegen/go_to_rust/tests/fixtures/struct_with_comments/input.txt
+++ b/aws_lambda_codegen/go_to_rust/tests/fixtures/struct_with_comments/input.txt
@@ -1,0 +1,5 @@
+// Foo
+type SimpleEmailEvent struct {
+  Records string `json:"fooBar"` // My cool thing
+  Records2 int `json:"blah"`
+}

--- a/aws_lambda_codegen/go_to_rust/tests/fixtures/struct_with_multiple_comments/expected.txt
+++ b/aws_lambda_codegen/go_to_rust/tests/fixtures/struct_with_multiple_comments/expected.txt
@@ -1,0 +1,6 @@
+/// Foo
+/// Bar
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct Whatever {
+    pub blah: i64,
+}

--- a/aws_lambda_codegen/go_to_rust/tests/fixtures/struct_with_multiple_comments/input.txt
+++ b/aws_lambda_codegen/go_to_rust/tests/fixtures/struct_with_multiple_comments/input.txt
@@ -1,0 +1,5 @@
+// Foo
+// Bar
+type Whatever struct {
+  blah int
+}

--- a/aws_lambda_codegen/go_to_rust/tests/fixtures/toplevel_comment/expected.txt
+++ b/aws_lambda_codegen/go_to_rust/tests/fixtures/toplevel_comment/expected.txt
@@ -1,0 +1,3 @@
+/// Doc comment
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct Foo;

--- a/aws_lambda_codegen/go_to_rust/tests/fixtures/toplevel_comment/input.txt
+++ b/aws_lambda_codegen/go_to_rust/tests/fixtures/toplevel_comment/input.txt
@@ -1,0 +1,8 @@
+// Top level comment 1
+
+import "whatever"
+
+// Top level comment 2
+
+// Doc comment
+type Foo struct { }

--- a/aws_lambda_codegen/go_to_rust/tests/integration.rs
+++ b/aws_lambda_codegen/go_to_rust/tests/integration.rs
@@ -1,0 +1,83 @@
+extern crate env_logger;
+extern crate glob;
+extern crate go_to_rust;
+extern crate rustc_test as test;
+
+use glob::glob;
+use std::env;
+use std::fs::File;
+use std::io::prelude::*;
+use std::io::BufReader;
+use std::path::Path;
+use std::path::PathBuf;
+use test::{DynTestFn, DynTestName, TestDesc, TestDescAndFn};
+
+fn mk_test(desc: &str, input: String, expect: String, expected_path: PathBuf) -> TestDescAndFn {
+    TestDescAndFn {
+        desc: TestDesc::new(DynTestName(desc.to_string())),
+        testfn: DynTestFn(Box::new(move || {
+            let (_, output) = go_to_rust::parse_go_string(input.clone()).expect("parser parses");
+
+            // Add support for recording fixtures.
+            if let Ok(_) = env::var("GO_TO_RUST_FIXTURE_RECORD") {
+                let mut f = File::create(expected_path.clone()).expect("fixture to be opened");
+                f.write_all(output.as_bytes())
+                    .expect("fixture to be written");
+            }
+
+            if output != go_to_rust::RustCode::new(expect.clone()) {
+                panic!(
+                    "\n- input -\n{}\n- got -\n{}\n- expected -\n{}\n",
+                    input, output, expect
+                );
+            }
+        })),
+    }
+}
+
+fn tests(src_dir: &Path) -> Vec<TestDescAndFn> {
+    let mut tests = vec![];
+
+    let entries = glob(&format!(
+        "{}/{}",
+        src_dir.to_string_lossy(),
+        "tests/fixtures/*"
+    )).expect("some fixtures");
+
+    // Loop over matched fixtures.
+    for entry in entries {
+        let fixture_path = entry.unwrap();
+        let input_path = fixture_path.clone().join("input.txt");
+        let expected_path = fixture_path.clone().join("expected.txt");
+
+        let data: Vec<String> = vec![input_path.clone(), expected_path.clone()]
+            .iter()
+            .map(|p| {
+                let file = File::open(&p).unwrap();
+                let mut reader = BufReader::new(file);
+                let mut text = String::new();
+                reader.read_to_string(&mut text).unwrap();
+                text
+            })
+            .collect();
+
+        let test_name = fixture_path
+            .file_stem()
+            .expect("fixture to have a file stem")
+            .to_string_lossy();
+
+        tests.push(mk_test(
+            &test_name,
+            data[0].clone(),
+            data[1].clone(),
+            expected_path.clone(),
+        ));
+    }
+
+    tests
+}
+
+fn main() {
+    let args: Vec<_> = env::args().collect();
+    test::test_main(&args, tests(Path::new(env!("CARGO_MANIFEST_DIR"))));
+}

--- a/aws_lambda_codegen/src/main.rs
+++ b/aws_lambda_codegen/src/main.rs
@@ -1,0 +1,151 @@
+extern crate go_to_rust;
+#[macro_use]
+extern crate quicli;
+
+use quicli::prelude::*;
+use std::collections::HashSet;
+use std::fs::File;
+use std::io::Write;
+use std::path::PathBuf;
+
+#[derive(Debug)]
+struct ParsedFile {
+    path: PathBuf,
+    go: go_to_rust::GoCode,
+    rust: go_to_rust::RustCode,
+}
+
+/// Generate rust code for AWS lambda events sourced from `aws-go-sdk`
+#[derive(Debug, StructOpt)]
+#[structopt(author = "")]
+struct Cli {
+    /// Path to `aws-go-sdk` checkout
+    #[structopt(long = "input", name = "AWS_GO_SDK_DIRECTORY", parse(from_os_str))]
+    sdk_location: PathBuf,
+    /// Output directory
+    #[structopt(long = "output", short = "o", name = "DIRECTORY", parse(from_os_str))]
+    output_location: PathBuf,
+    /// Overwrite existing files
+    #[structopt(long = "overwrite")]
+    overwrite: bool,
+    /// Verbose output. Pass many times for more log output
+    #[structopt(long = "verbose", short = "v", parse(from_occurrences))]
+    verbosity: u8,
+}
+
+fn get_blacklist() -> HashSet<String> {
+    let mut blacklist = HashSet::new();
+    // https://github.com/aws/aws-lambda-go/blob/master/events/attributevalue.go
+    blacklist.insert("attributevalue".to_string());
+    // https://github.com/aws/aws-lambda-go/blob/master/events/firehose.go
+    blacklist.insert("firehose".to_string());
+    // https://github.com/aws/aws-lambda-go/blob/master/events/cloudwatch_logs.go
+    blacklist.insert("cloudwatch_logs".to_string());
+    // https://github.com/aws/aws-lambda-go/blob/master/events/code_commit.go
+    blacklist.insert("code_commit".to_string());
+    // https://github.com/aws/aws-lambda-go/blob/master/events/dynamodb.go
+    blacklist.insert("dynamodb".to_string());
+    // https://github.com/aws/aws-lambda-go/blob/master/events/epoch_time.go
+    blacklist.insert("epoch_time".to_string());
+    // https://github.com/aws/aws-lambda-go/blob/master/events/epoch_time.go
+    blacklist.insert("epoch_time".to_string());
+
+    // The following are very close to working.
+    // https://github.com/aws/aws-lambda-go/blob/master/events/ses.go
+    blacklist.insert("ses".to_string());
+    // https://github.com/aws/aws-lambda-go/blob/master/events/lex.go
+    blacklist.insert("lex".to_string());
+    // https://github.com/aws/aws-lambda-go/blob/master/events/s3.go
+    blacklist.insert("s3".to_string());
+    // https://github.com/aws/aws-lambda-go/blob/master/events/kinesis.go
+    blacklist.insert("kinesis".to_string());
+    blacklist
+}
+
+fn overwrite_warning(path: &PathBuf, overwrite: bool) -> Option<()> {
+    if path.exists() && !overwrite {
+        error!(
+            "File already exists and `--overwrite` not specified. Skipping: {}",
+            path.to_string_lossy()
+        );
+        return Some(());
+    }
+    return None;
+}
+
+fn write_mod_index(
+    mod_path: &PathBuf,
+    parsed_files: &Vec<ParsedFile>,
+    overwrite: bool,
+) -> Result<()> {
+    if overwrite_warning(&mod_path, overwrite).is_none() {
+        let mut mod_content: Vec<String> = Vec::new();
+        for parsed in parsed_files {
+            mod_content.push(format!(
+                "pub mod {};",
+                parsed
+                    .path
+                    .file_stem()
+                    .expect("file stem")
+                    .to_string_lossy()
+            ));
+        }
+        let mut f = File::create(mod_path)?;
+        f.write_all(mod_content.join("\n").as_bytes())?;
+        f.write_all("\n".as_bytes())?;
+    }
+    Ok(())
+}
+
+main!(|args: Cli, log_level: verbosity| {
+    let mut parsed_files: Vec<ParsedFile> = Vec::new();
+
+    // The glob pattern we are going to use to find the go files with event defs.
+    let pattern = format!("{}/events/*.go", args.sdk_location.to_string_lossy());
+
+    // Some files we don't properly handle yet.
+    let blacklist = get_blacklist();
+
+    // Loop over matched files.
+    for path in glob(&pattern)? {
+        let x = path.clone();
+        let file_name = x.file_stem().expect("file stem").to_string_lossy();
+
+        // Filter out tests and blacklisted files.
+        if !file_name.contains("_test") && !blacklist.contains(&*file_name) {
+            info!("Parsing: {}", x.to_string_lossy());
+            let (go, rust) = go_to_rust::parse_go_file(&path)?;
+            debug!("Go ------v\n{}", go);
+            debug!("Rust-----v\n{}", rust);
+
+            parsed_files.push(ParsedFile { path, go, rust });
+        }
+    }
+
+    // Create the output location if needed.
+    if !args.output_location.exists() {
+        trace!("Creating directory: {:?}", args.output_location);
+        create_dir(&args.output_location)?;
+    }
+
+    // Write the files.
+    for parsed in &parsed_files {
+        let out_dir = args.output_location.clone();
+        let output_path = out_dir.join(
+            parsed
+                .path
+                .with_extension("rs")
+                .file_name()
+                .expect("a file name exists"),
+        );
+        if overwrite_warning(&output_path, args.overwrite).is_none() {
+            let mut f = File::create(output_path)?;
+            f.write_all(parsed.rust.as_bytes())?;
+            f.write_all("\n".as_bytes())?;
+        }
+    }
+
+    // Write the crate index.
+    let mod_path = args.output_location.clone().join("mod.rs");
+    write_mod_index(&mod_path, &parsed_files, args.overwrite)?;
+});

--- a/aws_lambda_events/Cargo.toml
+++ b/aws_lambda_events/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "aws_lambda_events"
+version = "0.1.0"
+authors = ["Christian Legnitto <christian@legnitto.com>"]
+
+[dependencies]
+serde = "1.0"
+serde_derive = "1.0"
+serde_json = "1.0"
+bytes = { version = "0.4", features = ["serde"] }
+chrono = { version = "0.4", features = ["serde"] }

--- a/aws_lambda_events/src/event.rs
+++ b/aws_lambda_events/src/event.rs
@@ -1,0 +1,3 @@
+// Additional layer of indirection in case we want to make upgrading easy
+// or provide translations in the future.
+pub use super::generated::*;

--- a/aws_lambda_events/src/generated/apigw.rs
+++ b/aws_lambda_events/src/generated/apigw.rs
@@ -1,0 +1,185 @@
+use bytes::Bytes;
+use std::collections::HashMap;
+
+/// `APIGatewayProxyRequest` contains data coming from the API Gateway proxy
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct APIGatewayProxyRequest {
+    /// The resource path defined in API Gateway
+    pub resource: String,
+    /// The url path for the caller
+    pub path: String,
+    #[serde(rename = "httpMethod")]
+    pub http_method: String,
+    pub headers: HashMap<String, String>,
+    #[serde(rename = "queryStringParameters")]
+    pub query_string_parameters: HashMap<String, String>,
+    #[serde(rename = "pathParameters")]
+    pub path_parameters: HashMap<String, String>,
+    #[serde(rename = "stageVariables")]
+    pub stage_variables: HashMap<String, String>,
+    #[serde(rename = "requestContext")]
+    pub request_context: APIGatewayProxyRequestContext,
+    pub body: String,
+    #[serde(rename = "isBase64Encoded")]
+    pub is_base64_encoded: Option<bool>,
+}
+
+/// `APIGatewayProxyResponse` configures the response to be returned by API Gateway for the request
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct APIGatewayProxyResponse {
+    #[serde(rename = "statusCode")]
+    pub status_code: i64,
+    pub headers: HashMap<String, String>,
+    pub body: String,
+    #[serde(rename = "isBase64Encoded")]
+    pub is_base64_encoded: Option<bool>,
+}
+
+/// `APIGatewayProxyRequestContext` contains the information to identify the AWS account and resources invoking the
+/// Lambda function. It also includes Cognito identity information for the caller.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct APIGatewayProxyRequestContext {
+    #[serde(rename = "accountId")]
+    pub account_id: String,
+    #[serde(rename = "resourceId")]
+    pub resource_id: String,
+    pub stage: String,
+    #[serde(rename = "requestId")]
+    pub request_id: String,
+    pub identity: APIGatewayRequestIdentity,
+    #[serde(rename = "resourcePath")]
+    pub resource_path: String,
+    pub authorizer: HashMap<String, Bytes>,
+    #[serde(rename = "httpMethod")]
+    pub http_method: String,
+    /// The API Gateway rest API Id
+    #[serde(rename = "apiId")]
+    pub apiid: String,
+}
+
+/// `APIGatewayRequestIdentity` contains identity information for the request caller.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct APIGatewayRequestIdentity {
+    #[serde(rename = "cognitoIdentityPoolId")]
+    pub cognito_identity_pool_id: String,
+    #[serde(rename = "accountId")]
+    pub account_id: String,
+    #[serde(rename = "cognitoIdentityId")]
+    pub cognito_identity_id: String,
+    pub caller: String,
+    #[serde(rename = "apiKey")]
+    pub api_key: String,
+    #[serde(rename = "sourceIp")]
+    pub source_ip: String,
+    #[serde(rename = "cognitoAuthenticationType")]
+    pub cognito_authentication_type: String,
+    #[serde(rename = "cognitoAuthenticationProvider")]
+    pub cognito_authentication_provider: String,
+    #[serde(rename = "userArn")]
+    pub user_arn: String,
+    #[serde(rename = "userAgent")]
+    pub user_agent: String,
+    pub user: String,
+}
+
+/// `APIGatewayCustomAuthorizerRequestTypeRequestIdentity` contains identity information for the request caller.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct APIGatewayCustomAuthorizerRequestTypeRequestIdentity {
+    #[serde(rename = "apiKey")]
+    pub api_key: String,
+    #[serde(rename = "sourceIp")]
+    pub source_ip: String,
+}
+
+/// `APIGatewayCustomAuthorizerContext` represents the expected format of an API Gateway custom authorizer response.
+/// Deprecated. Code should be updated to use the Authorizer map from APIGatewayRequestIdentity. Ex: Authorizer["principalId"]
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct APIGatewayCustomAuthorizerContext {
+    #[serde(rename = "principalId")]
+    pub principal_id: String,
+    #[serde(rename = "stringKey")]
+    pub string_key: Option<String>,
+    #[serde(rename = "numKey")]
+    pub num_key: Option<i64>,
+    #[serde(rename = "boolKey")]
+    pub bool_key: Option<bool>,
+}
+
+/// `APIGatewayCustomAuthorizerRequestTypeRequestContext` represents the expected format of an API Gateway custom authorizer response.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct APIGatewayCustomAuthorizerRequestTypeRequestContext {
+    pub path: String,
+    #[serde(rename = "accountId")]
+    pub account_id: String,
+    #[serde(rename = "resourceId")]
+    pub resource_id: String,
+    pub stage: String,
+    #[serde(rename = "requestId")]
+    pub request_id: String,
+    pub identity: APIGatewayCustomAuthorizerRequestTypeRequestIdentity,
+    #[serde(rename = "resourcePath")]
+    pub resource_path: String,
+    #[serde(rename = "httpMethod")]
+    pub http_method: String,
+    #[serde(rename = "apiId")]
+    pub apiid: String,
+}
+
+/// `APIGatewayCustomAuthorizerRequest` contains data coming in to a custom API Gateway authorizer function.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct APIGatewayCustomAuthorizerRequest {
+    #[serde(rename = "type")]
+    pub type_: String,
+    #[serde(rename = "authorizationToken")]
+    pub authorization_token: String,
+    #[serde(rename = "methodArn")]
+    pub method_arn: String,
+}
+
+/// `APIGatewayCustomAuthorizerRequestTypeRequest` contains data coming in to a custom API Gateway authorizer function.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct APIGatewayCustomAuthorizerRequestTypeRequest {
+    #[serde(rename = "type")]
+    pub type_: String,
+    #[serde(rename = "methodArn")]
+    pub method_arn: String,
+    pub resource: String,
+    pub path: String,
+    #[serde(rename = "httpMethod")]
+    pub http_method: String,
+    pub headers: HashMap<String, String>,
+    #[serde(rename = "queryStringParameters")]
+    pub query_string_parameters: HashMap<String, String>,
+    #[serde(rename = "pathParameters")]
+    pub path_parameters: HashMap<String, String>,
+    #[serde(rename = "stageVariables")]
+    pub stage_variables: HashMap<String, String>,
+    #[serde(rename = "requestContext")]
+    pub request_context: APIGatewayCustomAuthorizerRequestTypeRequestContext,
+}
+
+/// `APIGatewayCustomAuthorizerResponse` represents the expected format of an API Gateway authorization response.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct APIGatewayCustomAuthorizerResponse {
+    #[serde(rename = "principalId")]
+    pub principal_id: String,
+    #[serde(rename = "policyDocument")]
+    pub policy_document: APIGatewayCustomAuthorizerPolicy,
+    pub context: Option<HashMap<String, Bytes>>,
+    #[serde(rename = "usageIdentifierKey")]
+    pub usage_identifier_key: Option<String>,
+}
+
+/// `APIGatewayCustomAuthorizerPolicy` represents an IAM policy
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct APIGatewayCustomAuthorizerPolicy {
+    pub version: String,
+    pub statement: Vec<IAMPolicyStatement>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct IAMPolicyStatement {
+    pub action: Vec<String>,
+    pub effect: String,
+    pub resource: Vec<String>,
+}

--- a/aws_lambda_events/src/generated/autoscaling.rs
+++ b/aws_lambda_events/src/generated/autoscaling.rs
@@ -1,0 +1,27 @@
+use bytes::Bytes;
+use chrono::{DateTime, Utc};
+use std::collections::HashMap;
+
+/// `AutoScalingEvent` struct is used to parse the json for auto scaling event types //
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct AutoScalingEvent {
+    /// The version of event data
+    pub version: String,
+    /// The unique ID of the event
+    pub id: String,
+    /// Details about event type
+    #[serde(rename = "detail-type")]
+    pub detail_type: String,
+    /// Source of the event
+    pub source: String,
+    /// AccountId
+    #[serde(rename = "account")]
+    pub account_id: String,
+    /// Event timestamp
+    pub time: DateTime<Utc>,
+    /// Region of event
+    pub region: String,
+    /// Information about resources impacted by event
+    pub resources: Vec<String>,
+    pub detail: HashMap<String, Bytes>,
+}

--- a/aws_lambda_events/src/generated/cloudwatch_events.rs
+++ b/aws_lambda_events/src/generated/cloudwatch_events.rs
@@ -1,0 +1,19 @@
+use chrono::{DateTime, Utc};
+use serde_json::Value;
+
+/// `CloudWatchEvent` is the outer structure of an event sent via CloudWatch Events.
+/// For examples of events that come via CloudWatch Events, see https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/EventTypes.html
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct CloudWatchEvent {
+    pub version: String,
+    pub id: String,
+    #[serde(rename = "detail-type")]
+    pub detail_type: String,
+    pub source: String,
+    #[serde(rename = "account")]
+    pub account_id: String,
+    pub time: DateTime<Utc>,
+    pub region: String,
+    pub resources: Vec<String>,
+    pub detail: Value,
+}

--- a/aws_lambda_events/src/generated/codepipeline_job.rs
+++ b/aws_lambda_events/src/generated/codepipeline_job.rs
@@ -1,0 +1,99 @@
+/// `CodePipelineEvent` contains data from an event sent from AWS Codepipeline
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct CodePipelineEvent {
+    #[serde(rename = "CodePipeline.job")]
+    pub code_pipeline_job: CodePipelineJob,
+}
+
+/// `CodePipelineJob` represents a job from an AWS CodePipeline event
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct CodePipelineJob {
+    pub id: String,
+    #[serde(rename = "accountId")]
+    pub account_id: String,
+    pub data: CodePipelineData,
+}
+
+/// `CodePipelineData` represents a job from an AWS CodePipeline event
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct CodePipelineData {
+    #[serde(rename = "actionConfiguration")]
+    pub action_configuration: CodePipelineActionConfiguration,
+    #[serde(rename = "inputArtifacts")]
+    pub input_artifacts: Vec<CodePipelineInputArtifact>,
+    #[serde(rename = "outputArtifacts")]
+    pub out_put_artifacts: Vec<CodePipelineOutputArtifact>,
+    #[serde(rename = "artifactCredentials")]
+    pub artifact_credentials: CodePipelineArtifactCredentials,
+    #[serde(rename = "continuationToken")]
+    pub continuation_token: String,
+}
+
+/// `CodePipelineActionConfiguration` represents an Action Configuration
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct CodePipelineActionConfiguration {
+    pub configuration: CodePipelineConfiguration,
+}
+
+/// `CodePipelineConfiguration` represents a configuration for an Action Configuration
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct CodePipelineConfiguration {
+    #[serde(rename = "FunctionName")]
+    pub function_name: String,
+    #[serde(rename = "UserParameters")]
+    pub user_parameters: String,
+}
+
+/// `CodePipelineInputArtifact` represents an input artifact
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct CodePipelineInputArtifact {
+    pub location: CodePipelineInputLocation,
+    pub revision: String,
+    pub name: String,
+}
+
+/// `CodePipelineInputLocation` represents a input location
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct CodePipelineInputLocation {
+    #[serde(rename = "s3Location")]
+    pub s3_location: CodePipelineS3Location,
+    #[serde(rename = "type")]
+    pub location_type: String,
+}
+
+/// `CodePipelineS3Location` represents an s3 input location
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct CodePipelineS3Location {
+    #[serde(rename = "bucketName")]
+    pub bucket_name: String,
+    #[serde(rename = "objectKey")]
+    pub object_key: String,
+}
+
+/// `CodePipelineOutputArtifact` represents an output artifact
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct CodePipelineOutputArtifact {
+    pub location: CodePipelineInputLocation,
+    pub revision: String,
+    pub name: String,
+}
+
+/// `CodePipelineOutputLocation` represents a output location
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct CodePipelineOutputLocation {
+    #[serde(rename = "s3Location")]
+    pub s3_location: CodePipelineS3Location,
+    #[serde(rename = "type")]
+    pub location_type: String,
+}
+
+/// `CodePipelineArtifactCredentials` represents CodePipeline artifact credentials
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct CodePipelineArtifactCredentials {
+    #[serde(rename = "secretAccessKey")]
+    pub secret_access_key: String,
+    #[serde(rename = "sessionToken")]
+    pub session_token: String,
+    #[serde(rename = "accessKeyId")]
+    pub access_key_id: String,
+}

--- a/aws_lambda_events/src/generated/cognito.rs
+++ b/aws_lambda_events/src/generated/cognito.rs
@@ -1,0 +1,28 @@
+use std::collections::HashMap;
+
+/// `CognitoEvent` contains data from an event sent from AWS Cognito
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct CognitoEvent {
+    #[serde(rename = "datasetName")]
+    pub dataset_name: String,
+    #[serde(rename = "datasetRecords")]
+    pub dataset_records: HashMap<String, CognitoDatasetRecord>,
+    #[serde(rename = "eventType")]
+    pub event_type: String,
+    #[serde(rename = "identityId")]
+    pub identity_id: String,
+    #[serde(rename = "identityPoolId")]
+    pub identity_pool_id: String,
+    pub region: String,
+    pub version: i64,
+}
+
+/// `CognitoDatasetRecord` represents a record from an AWS Cognito event
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct CognitoDatasetRecord {
+    #[serde(rename = "newValue")]
+    pub new_value: String,
+    #[serde(rename = "oldValue")]
+    pub old_value: String,
+    pub op: String,
+}

--- a/aws_lambda_events/src/generated/config.rs
+++ b/aws_lambda_events/src/generated/config.rs
@@ -1,0 +1,30 @@
+/// `ConfigEvent` contains data from an event sent from AWS Config
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ConfigEvent {
+    /// The ID of the AWS account that owns the rule
+    #[serde(rename = "accountId")]
+    pub account_id: String,
+    /// The ARN that AWS Config assigned to the rule
+    #[serde(rename = "configRuleArn")]
+    pub config_rule_arn: String,
+    #[serde(rename = "configRuleId")]
+    pub config_rule_id: String,
+    /// The name that you assigned to the rule that caused AWS Config to publish the event
+    #[serde(rename = "configRuleName")]
+    pub config_rule_name: String,
+    /// A boolean value that indicates whether the AWS resource to be evaluated has been removed from the rule's scope
+    #[serde(rename = "eventLeftScope")]
+    pub event_left_scope: bool,
+    #[serde(rename = "executionRoleArn")]
+    pub execution_role_arn: String,
+    /// If the event is published in response to a resource configuration change, this value contains a JSON configuration item
+    #[serde(rename = "invokingEvent")]
+    pub invoking_event: String,
+    /// A token that the function must pass to AWS Config with the PutEvaluations call
+    #[serde(rename = "resultToken")]
+    pub result_token: String,
+    /// Key/value pairs that the function processes as part of its evaluation logic
+    #[serde(rename = "ruleParameters")]
+    pub rule_parameters: String,
+    pub version: String,
+}

--- a/aws_lambda_events/src/generated/mod.rs
+++ b/aws_lambda_events/src/generated/mod.rs
@@ -1,0 +1,7 @@
+pub mod apigw;
+pub mod autoscaling;
+pub mod cloudwatch_events;
+pub mod codepipeline_job;
+pub mod cognito;
+pub mod config;
+pub mod sns;

--- a/aws_lambda_events/src/generated/sns.rs
+++ b/aws_lambda_events/src/generated/sns.rs
@@ -1,0 +1,47 @@
+use bytes::Bytes;
+use chrono::{DateTime, Utc};
+use std::collections::HashMap;
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct SNSEvent {
+    #[serde(rename = "Records")]
+    pub records: Vec<SNSEventRecord>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct SNSEventRecord {
+    #[serde(rename = "EventVersion")]
+    pub event_version: String,
+    #[serde(rename = "EventSubscriptionArn")]
+    pub event_subscription_arn: String,
+    #[serde(rename = "EventSource")]
+    pub event_source: String,
+    #[serde(rename = "Sns")]
+    pub sns: SNSEntity,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct SNSEntity {
+    #[serde(rename = "Signature")]
+    pub signature: String,
+    #[serde(rename = "MessageId")]
+    pub message_id: String,
+    #[serde(rename = "Type")]
+    pub type_: String,
+    #[serde(rename = "TopicArn")]
+    pub topic_arn: String,
+    #[serde(rename = "MessageAttributes")]
+    pub message_attributes: HashMap<String, Bytes>,
+    #[serde(rename = "SignatureVersion")]
+    pub signature_version: String,
+    #[serde(rename = "Timestamp")]
+    pub timestamp: DateTime<Utc>,
+    #[serde(rename = "SigningCertUrl")]
+    pub signing_cert_url: String,
+    #[serde(rename = "Message")]
+    pub message: String,
+    #[serde(rename = "UnsubscribeUrl")]
+    pub unsubscribe_url: String,
+    #[serde(rename = "Subject")]
+    pub subject: String,
+}

--- a/aws_lambda_events/src/lib.rs
+++ b/aws_lambda_events/src/lib.rs
@@ -1,0 +1,9 @@
+#[macro_use]
+extern crate serde_derive;
+extern crate bytes;
+extern crate chrono;
+extern crate serde;
+extern crate serde_json;
+
+pub mod event;
+mod generated;


### PR DESCRIPTION
Hi! I was working on the same thing, might as well coordinate :-D.

This is a binary (`aws_lambda_codegen`) that codegen's Rust structs from the Go AWS event defs in https://github.com/aws/aws-lambda-go/blob/master/events/. It is not meant to be published and exists to generate the structs in `aws_lambda_events`.

This PR also includes the output from running the binary in a crate `aws_lambda_events`, which is meant to be published.

(as an aside, I may clean up the embedded `go_to_rust` crate and release it on its own).