### PR TITLE
make it a bit easier to switch between `string-null-none` and `string-null-empty` styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,11 @@ are available as crate features so you can choose the behavior and API that work
   - **Pros:** _you do not have to `unwrap()`/`expect()`/`match` every string field before using._
   - **Cons:** _Not idiomatic Rust. You manually have to check for `""` if you want to know the difference between a real value or an empty value._
 
+  Change your `Cargo.toml` dependency to:
+```toml
+aws_lambda = { git = "https://github.com/srijs/rust-aws-lambda", features = ["string-null-empty"] }
+```
+
 ### Context
 
 While your function is running you can call `Context::current()` to get additional information, such as the ARN of your lambda, the Amazon request id or the Cognito identity of the calling application.

--- a/aws_lambda_events/src/custom_serde.rs
+++ b/aws_lambda_events/src/custom_serde.rs
@@ -105,7 +105,7 @@ where
 }
 
 /// Deserializes `Option<String>`, mapping JSON `null` or the empty string `""` to `None`.
-#[cfg(feature = "string-null-none")]
+#[cfg(not(feature = "string-null-empty"))]
 pub(crate) fn deserialize_lambda_string<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
 where
     D: Deserializer<'de>,

--- a/aws_lambda_events/src/generated/apigw.rs
+++ b/aws_lambda_events/src/generated/apigw.rs
@@ -6,7 +6,7 @@ use serde_json::Value;
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct ApiGatewayProxyRequest {
     /// The resource path defined in API Gateway
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     pub resource: Option<String>,
@@ -16,7 +16,7 @@ pub struct ApiGatewayProxyRequest {
     #[serde(default)]
     pub resource: String,
     /// The url path for the caller
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     pub path: Option<String>,
@@ -25,7 +25,7 @@ pub struct ApiGatewayProxyRequest {
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     pub path: String,
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "httpMethod")]
@@ -48,7 +48,7 @@ pub struct ApiGatewayProxyRequest {
     pub stage_variables: HashMap<String, String>,
     #[serde(rename = "requestContext")]
     pub request_context: ApiGatewayProxyRequestContext,
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     pub body: Option<String>,
@@ -67,7 +67,7 @@ pub struct ApiGatewayProxyResponse {
     pub status_code: i64,
     #[serde(deserialize_with = "deserialize_lambda_map")]
     pub headers: HashMap<String, String>,
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     pub body: Option<String>,
@@ -83,7 +83,7 @@ pub struct ApiGatewayProxyResponse {
 /// Lambda function. It also includes Cognito identity information for the caller.
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct ApiGatewayProxyRequestContext {
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "accountId")]
@@ -93,7 +93,7 @@ pub struct ApiGatewayProxyRequestContext {
     #[serde(default)]
     #[serde(rename = "accountId")]
     pub account_id: String,
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "resourceId")]
@@ -103,7 +103,7 @@ pub struct ApiGatewayProxyRequestContext {
     #[serde(default)]
     #[serde(rename = "resourceId")]
     pub resource_id: String,
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     pub stage: Option<String>,
@@ -111,7 +111,7 @@ pub struct ApiGatewayProxyRequestContext {
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     pub stage: String,
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "requestId")]
@@ -122,7 +122,7 @@ pub struct ApiGatewayProxyRequestContext {
     #[serde(rename = "requestId")]
     pub request_id: String,
     pub identity: ApiGatewayRequestIdentity,
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "resourcePath")]
@@ -134,7 +134,7 @@ pub struct ApiGatewayProxyRequestContext {
     pub resource_path: String,
     #[serde(deserialize_with = "deserialize_lambda_map")]
     pub authorizer: HashMap<String, Value>,
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "httpMethod")]
@@ -145,7 +145,7 @@ pub struct ApiGatewayProxyRequestContext {
     #[serde(rename = "httpMethod")]
     pub http_method: String,
     /// The API Gateway rest API Id
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "apiId")]
@@ -161,7 +161,7 @@ pub struct ApiGatewayProxyRequestContext {
 /// `ApiGatewayRequestIdentity` contains identity information for the request caller.
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct ApiGatewayRequestIdentity {
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "cognitoIdentityPoolId")]
@@ -171,7 +171,7 @@ pub struct ApiGatewayRequestIdentity {
     #[serde(default)]
     #[serde(rename = "cognitoIdentityPoolId")]
     pub cognito_identity_pool_id: String,
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "accountId")]
@@ -181,7 +181,7 @@ pub struct ApiGatewayRequestIdentity {
     #[serde(default)]
     #[serde(rename = "accountId")]
     pub account_id: String,
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "cognitoIdentityId")]
@@ -191,7 +191,7 @@ pub struct ApiGatewayRequestIdentity {
     #[serde(default)]
     #[serde(rename = "cognitoIdentityId")]
     pub cognito_identity_id: String,
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     pub caller: Option<String>,
@@ -199,7 +199,7 @@ pub struct ApiGatewayRequestIdentity {
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     pub caller: String,
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "apiKey")]
@@ -209,7 +209,7 @@ pub struct ApiGatewayRequestIdentity {
     #[serde(default)]
     #[serde(rename = "apiKey")]
     pub api_key: String,
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "sourceIp")]
@@ -219,7 +219,7 @@ pub struct ApiGatewayRequestIdentity {
     #[serde(default)]
     #[serde(rename = "sourceIp")]
     pub source_ip: String,
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "cognitoAuthenticationType")]
@@ -229,7 +229,7 @@ pub struct ApiGatewayRequestIdentity {
     #[serde(default)]
     #[serde(rename = "cognitoAuthenticationType")]
     pub cognito_authentication_type: String,
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "cognitoAuthenticationProvider")]
@@ -239,7 +239,7 @@ pub struct ApiGatewayRequestIdentity {
     #[serde(default)]
     #[serde(rename = "cognitoAuthenticationProvider")]
     pub cognito_authentication_provider: String,
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "userArn")]
@@ -249,7 +249,7 @@ pub struct ApiGatewayRequestIdentity {
     #[serde(default)]
     #[serde(rename = "userArn")]
     pub user_arn: String,
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "userAgent")]
@@ -259,7 +259,7 @@ pub struct ApiGatewayRequestIdentity {
     #[serde(default)]
     #[serde(rename = "userAgent")]
     pub user_agent: String,
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     pub user: Option<String>,
@@ -272,7 +272,7 @@ pub struct ApiGatewayRequestIdentity {
 /// `ApiGatewayCustomAuthorizerRequestTypeRequestIdentity` contains identity information for the request caller.
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct ApiGatewayCustomAuthorizerRequestTypeRequestIdentity {
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "apiKey")]
@@ -282,7 +282,7 @@ pub struct ApiGatewayCustomAuthorizerRequestTypeRequestIdentity {
     #[serde(default)]
     #[serde(rename = "apiKey")]
     pub api_key: String,
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "sourceIp")]
@@ -311,7 +311,7 @@ pub struct ApiGatewayCustomAuthorizerContext {
 /// `ApiGatewayCustomAuthorizerRequestTypeRequestContext` represents the expected format of an API Gateway custom authorizer response.
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct ApiGatewayCustomAuthorizerRequestTypeRequestContext {
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     pub path: Option<String>,
@@ -319,7 +319,7 @@ pub struct ApiGatewayCustomAuthorizerRequestTypeRequestContext {
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     pub path: String,
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "accountId")]
@@ -329,7 +329,7 @@ pub struct ApiGatewayCustomAuthorizerRequestTypeRequestContext {
     #[serde(default)]
     #[serde(rename = "accountId")]
     pub account_id: String,
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "resourceId")]
@@ -339,7 +339,7 @@ pub struct ApiGatewayCustomAuthorizerRequestTypeRequestContext {
     #[serde(default)]
     #[serde(rename = "resourceId")]
     pub resource_id: String,
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     pub stage: Option<String>,
@@ -347,7 +347,7 @@ pub struct ApiGatewayCustomAuthorizerRequestTypeRequestContext {
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     pub stage: String,
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "requestId")]
@@ -358,7 +358,7 @@ pub struct ApiGatewayCustomAuthorizerRequestTypeRequestContext {
     #[serde(rename = "requestId")]
     pub request_id: String,
     pub identity: ApiGatewayCustomAuthorizerRequestTypeRequestIdentity,
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "resourcePath")]
@@ -368,7 +368,7 @@ pub struct ApiGatewayCustomAuthorizerRequestTypeRequestContext {
     #[serde(default)]
     #[serde(rename = "resourcePath")]
     pub resource_path: String,
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "httpMethod")]
@@ -378,7 +378,7 @@ pub struct ApiGatewayCustomAuthorizerRequestTypeRequestContext {
     #[serde(default)]
     #[serde(rename = "httpMethod")]
     pub http_method: String,
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "apiId")]
@@ -393,7 +393,7 @@ pub struct ApiGatewayCustomAuthorizerRequestTypeRequestContext {
 /// `ApiGatewayCustomAuthorizerRequest` contains data coming in to a custom API Gateway authorizer function.
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct ApiGatewayCustomAuthorizerRequest {
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "type")]
@@ -403,7 +403,7 @@ pub struct ApiGatewayCustomAuthorizerRequest {
     #[serde(default)]
     #[serde(rename = "type")]
     pub type_: String,
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "authorizationToken")]
@@ -413,7 +413,7 @@ pub struct ApiGatewayCustomAuthorizerRequest {
     #[serde(default)]
     #[serde(rename = "authorizationToken")]
     pub authorization_token: String,
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "methodArn")]
@@ -428,7 +428,7 @@ pub struct ApiGatewayCustomAuthorizerRequest {
 /// `ApiGatewayCustomAuthorizerRequestTypeRequest` contains data coming in to a custom API Gateway authorizer function.
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct ApiGatewayCustomAuthorizerRequestTypeRequest {
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "type")]
@@ -438,7 +438,7 @@ pub struct ApiGatewayCustomAuthorizerRequestTypeRequest {
     #[serde(default)]
     #[serde(rename = "type")]
     pub type_: String,
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "methodArn")]
@@ -448,7 +448,7 @@ pub struct ApiGatewayCustomAuthorizerRequestTypeRequest {
     #[serde(default)]
     #[serde(rename = "methodArn")]
     pub method_arn: String,
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     pub resource: Option<String>,
@@ -456,7 +456,7 @@ pub struct ApiGatewayCustomAuthorizerRequestTypeRequest {
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     pub resource: String,
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     pub path: Option<String>,
@@ -464,7 +464,7 @@ pub struct ApiGatewayCustomAuthorizerRequestTypeRequest {
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     pub path: String,
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "httpMethod")]
@@ -492,7 +492,7 @@ pub struct ApiGatewayCustomAuthorizerRequestTypeRequest {
 /// `ApiGatewayCustomAuthorizerResponse` represents the expected format of an API Gateway authorization response.
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct ApiGatewayCustomAuthorizerResponse {
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "principalId")]
@@ -513,7 +513,7 @@ pub struct ApiGatewayCustomAuthorizerResponse {
 /// `ApiGatewayCustomAuthorizerPolicy` represents an IAM policy
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct ApiGatewayCustomAuthorizerPolicy {
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     pub version: Option<String>,
@@ -527,7 +527,7 @@ pub struct ApiGatewayCustomAuthorizerPolicy {
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct IamPolicyStatement {
     pub action: Vec<String>,
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     pub effect: Option<String>,

--- a/aws_lambda_events/src/generated/autoscaling.rs
+++ b/aws_lambda_events/src/generated/autoscaling.rs
@@ -7,7 +7,7 @@ use std::collections::HashMap;
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct AutoScalingEvent {
     /// The version of event data
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     pub version: Option<String>,
@@ -17,7 +17,7 @@ pub struct AutoScalingEvent {
     #[serde(default)]
     pub version: String,
     /// The unique ID of the event
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     pub id: Option<String>,
@@ -27,7 +27,7 @@ pub struct AutoScalingEvent {
     #[serde(default)]
     pub id: String,
     /// Details about event type
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "detail-type")]
@@ -39,7 +39,7 @@ pub struct AutoScalingEvent {
     #[serde(rename = "detail-type")]
     pub detail_type: String,
     /// Source of the event
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     pub source: Option<String>,
@@ -49,7 +49,7 @@ pub struct AutoScalingEvent {
     #[serde(default)]
     pub source: String,
     /// AccountId
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "account")]
@@ -63,7 +63,7 @@ pub struct AutoScalingEvent {
     /// Event timestamp
     pub time: DateTime<Utc>,
     /// Region of event
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     pub region: Option<String>,

--- a/aws_lambda_events/src/generated/cloudwatch_events.rs
+++ b/aws_lambda_events/src/generated/cloudwatch_events.rs
@@ -6,7 +6,7 @@ use serde_json::Value;
 /// For examples of events that come via CloudWatch Events, see https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/EventTypes.html
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct CloudWatchEvent {
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     pub version: Option<String>,
@@ -14,7 +14,7 @@ pub struct CloudWatchEvent {
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     pub version: String,
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     pub id: Option<String>,
@@ -22,7 +22,7 @@ pub struct CloudWatchEvent {
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     pub id: String,
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "detail-type")]
@@ -32,7 +32,7 @@ pub struct CloudWatchEvent {
     #[serde(default)]
     #[serde(rename = "detail-type")]
     pub detail_type: String,
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     pub source: Option<String>,
@@ -40,7 +40,7 @@ pub struct CloudWatchEvent {
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     pub source: String,
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "account")]
@@ -51,7 +51,7 @@ pub struct CloudWatchEvent {
     #[serde(rename = "account")]
     pub account_id: String,
     pub time: DateTime<Utc>,
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     pub region: Option<String>,

--- a/aws_lambda_events/src/generated/cloudwatch_logs.rs
+++ b/aws_lambda_events/src/generated/cloudwatch_logs.rs
@@ -11,7 +11,7 @@ pub struct CloudwatchLogsEvent {
 /// of a cloudwatch logs event
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct CloudwatchLogsRawData {
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     pub data: Option<String>,
@@ -24,7 +24,7 @@ pub struct CloudwatchLogsRawData {
 /// `CloudwatchLogsData` is an unmarshal'd, ungzip'd, cloudwatch logs event
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct CloudwatchLogsData {
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     pub owner: Option<String>,
@@ -32,7 +32,7 @@ pub struct CloudwatchLogsData {
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     pub owner: String,
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "logGroup")]
@@ -42,7 +42,7 @@ pub struct CloudwatchLogsData {
     #[serde(default)]
     #[serde(rename = "logGroup")]
     pub log_group: String,
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "logStream")]
@@ -54,7 +54,7 @@ pub struct CloudwatchLogsData {
     pub log_stream: String,
     #[serde(rename = "subscriptionFilters")]
     pub subscription_filters: Vec<String>,
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "messageType")]
@@ -71,7 +71,7 @@ pub struct CloudwatchLogsData {
 /// LogEvent represents a log entry from cloudwatch logs
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct CloudwatchLogsLogEvent {
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     pub id: Option<String>,
@@ -80,7 +80,7 @@ pub struct CloudwatchLogsLogEvent {
     #[serde(default)]
     pub id: String,
     pub timestamp: i64,
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     pub message: Option<String>,

--- a/aws_lambda_events/src/generated/code_commit.rs
+++ b/aws_lambda_events/src/generated/code_commit.rs
@@ -13,7 +13,7 @@ pub type CodeCommitEventTime = DateTime<Utc>;
 /// represents a CodeCommit record
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct CodeCommitRecord {
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "eventId")]
@@ -23,7 +23,7 @@ pub struct CodeCommitRecord {
     #[serde(default)]
     #[serde(rename = "eventId")]
     pub event_id: String,
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "eventVersion")]
@@ -35,7 +35,7 @@ pub struct CodeCommitRecord {
     pub event_version: String,
     #[serde(rename = "eventTime")]
     pub event_time: CodeCommitEventTime,
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "eventTriggerName")]
@@ -49,7 +49,7 @@ pub struct CodeCommitRecord {
     pub event_part_number: u64,
     #[serde(rename = "codecommit")]
     pub code_commit: CodeCommitCodeCommit,
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "eventName")]
@@ -59,7 +59,7 @@ pub struct CodeCommitRecord {
     #[serde(default)]
     #[serde(rename = "eventName")]
     pub event_name: String,
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "eventTriggerConfigId")]
@@ -69,7 +69,7 @@ pub struct CodeCommitRecord {
     #[serde(default)]
     #[serde(rename = "eventTriggerConfigId")]
     pub event_trigger_config_id: String,
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "eventSourceARN")]
@@ -79,7 +79,7 @@ pub struct CodeCommitRecord {
     #[serde(default)]
     #[serde(rename = "eventSourceARN")]
     pub event_source_arn: String,
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "userIdentityARN")]
@@ -89,7 +89,7 @@ pub struct CodeCommitRecord {
     #[serde(default)]
     #[serde(rename = "userIdentityARN")]
     pub user_identity_arn: String,
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "eventSource")]
@@ -99,7 +99,7 @@ pub struct CodeCommitRecord {
     #[serde(default)]
     #[serde(rename = "eventSource")]
     pub event_source: String,
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "awsRegion")]
@@ -122,7 +122,7 @@ pub struct CodeCommitCodeCommit {
 /// `CodeCommitReference` represents a Reference object in a CodeCommit object
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct CodeCommitReference {
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     pub commit: Option<String>,
@@ -130,7 +130,7 @@ pub struct CodeCommitReference {
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     pub commit: String,
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "ref")]

--- a/aws_lambda_events/src/generated/codepipeline_job.rs
+++ b/aws_lambda_events/src/generated/codepipeline_job.rs
@@ -10,7 +10,7 @@ pub struct CodePipelineEvent {
 /// `CodePipelineJob` represents a job from an AWS CodePipeline event
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct CodePipelineJob {
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     pub id: Option<String>,
@@ -18,7 +18,7 @@ pub struct CodePipelineJob {
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     pub id: String,
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "accountId")]
@@ -42,7 +42,7 @@ pub struct CodePipelineData {
     pub out_put_artifacts: Vec<CodePipelineOutputArtifact>,
     #[serde(rename = "artifactCredentials")]
     pub artifact_credentials: CodePipelineArtifactCredentials,
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "continuationToken")]
@@ -63,7 +63,7 @@ pub struct CodePipelineActionConfiguration {
 /// `CodePipelineConfiguration` represents a configuration for an Action Configuration
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct CodePipelineConfiguration {
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "FunctionName")]
@@ -73,7 +73,7 @@ pub struct CodePipelineConfiguration {
     #[serde(default)]
     #[serde(rename = "FunctionName")]
     pub function_name: String,
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "UserParameters")]
@@ -90,7 +90,7 @@ pub struct CodePipelineConfiguration {
 pub struct CodePipelineInputArtifact {
     pub location: CodePipelineInputLocation,
     pub revision: Option<String>,
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     pub name: Option<String>,
@@ -105,7 +105,7 @@ pub struct CodePipelineInputArtifact {
 pub struct CodePipelineInputLocation {
     #[serde(rename = "s3Location")]
     pub s3_location: CodePipelineS3Location,
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "type")]
@@ -120,7 +120,7 @@ pub struct CodePipelineInputLocation {
 /// `CodePipelineS3Location` represents an s3 input location
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct CodePipelineS3Location {
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "bucketName")]
@@ -130,7 +130,7 @@ pub struct CodePipelineS3Location {
     #[serde(default)]
     #[serde(rename = "bucketName")]
     pub bucket_name: String,
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "objectKey")]
@@ -147,7 +147,7 @@ pub struct CodePipelineS3Location {
 pub struct CodePipelineOutputArtifact {
     pub location: CodePipelineInputLocation,
     pub revision: Option<String>,
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     pub name: Option<String>,
@@ -162,7 +162,7 @@ pub struct CodePipelineOutputArtifact {
 pub struct CodePipelineOutputLocation {
     #[serde(rename = "s3Location")]
     pub s3_location: CodePipelineS3Location,
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "type")]
@@ -177,7 +177,7 @@ pub struct CodePipelineOutputLocation {
 /// `CodePipelineArtifactCredentials` represents CodePipeline artifact credentials
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct CodePipelineArtifactCredentials {
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "secretAccessKey")]
@@ -187,7 +187,7 @@ pub struct CodePipelineArtifactCredentials {
     #[serde(default)]
     #[serde(rename = "secretAccessKey")]
     pub secret_access_key: String,
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "sessionToken")]
@@ -197,7 +197,7 @@ pub struct CodePipelineArtifactCredentials {
     #[serde(default)]
     #[serde(rename = "sessionToken")]
     pub session_token: String,
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "accessKeyId")]

--- a/aws_lambda_events/src/generated/cognito.rs
+++ b/aws_lambda_events/src/generated/cognito.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 /// `CognitoEvent` contains data from an event sent from AWS Cognito Sync
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct CognitoEvent {
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "datasetName")]
@@ -17,7 +17,7 @@ pub struct CognitoEvent {
     #[serde(deserialize_with = "deserialize_lambda_map")]
     #[serde(rename = "datasetRecords")]
     pub dataset_records: HashMap<String, CognitoDatasetRecord>,
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "eventType")]
@@ -27,7 +27,7 @@ pub struct CognitoEvent {
     #[serde(default)]
     #[serde(rename = "eventType")]
     pub event_type: String,
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "identityId")]
@@ -37,7 +37,7 @@ pub struct CognitoEvent {
     #[serde(default)]
     #[serde(rename = "identityId")]
     pub identity_id: String,
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "identityPoolId")]
@@ -47,7 +47,7 @@ pub struct CognitoEvent {
     #[serde(default)]
     #[serde(rename = "identityPoolId")]
     pub identity_pool_id: String,
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     pub region: Option<String>,
@@ -61,7 +61,7 @@ pub struct CognitoEvent {
 /// `CognitoDatasetRecord` represents a record from an AWS Cognito Sync event
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct CognitoDatasetRecord {
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "newValue")]
@@ -71,7 +71,7 @@ pub struct CognitoDatasetRecord {
     #[serde(default)]
     #[serde(rename = "newValue")]
     pub new_value: String,
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "oldValue")]
@@ -81,7 +81,7 @@ pub struct CognitoDatasetRecord {
     #[serde(default)]
     #[serde(rename = "oldValue")]
     pub old_value: String,
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     pub op: Option<String>,

--- a/aws_lambda_events/src/generated/config.rs
+++ b/aws_lambda_events/src/generated/config.rs
@@ -4,7 +4,7 @@ use custom_serde::*;
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct ConfigEvent {
     /// The ID of the AWS account that owns the rule
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "accountId")]
@@ -16,7 +16,7 @@ pub struct ConfigEvent {
     #[serde(rename = "accountId")]
     pub account_id: String,
     /// The ARN that AWS Config assigned to the rule
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "configRuleArn")]
@@ -27,7 +27,7 @@ pub struct ConfigEvent {
     #[serde(default)]
     #[serde(rename = "configRuleArn")]
     pub config_rule_arn: String,
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "configRuleId")]
@@ -38,7 +38,7 @@ pub struct ConfigEvent {
     #[serde(rename = "configRuleId")]
     pub config_rule_id: String,
     /// The name that you assigned to the rule that caused AWS Config to publish the event
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "configRuleName")]
@@ -52,7 +52,7 @@ pub struct ConfigEvent {
     /// A boolean value that indicates whether the AWS resource to be evaluated has been removed from the rule's scope
     #[serde(rename = "eventLeftScope")]
     pub event_left_scope: bool,
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "executionRoleArn")]
@@ -63,7 +63,7 @@ pub struct ConfigEvent {
     #[serde(rename = "executionRoleArn")]
     pub execution_role_arn: String,
     /// If the event is published in response to a resource configuration change, this value contains a JSON configuration item
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "invokingEvent")]
@@ -75,7 +75,7 @@ pub struct ConfigEvent {
     #[serde(rename = "invokingEvent")]
     pub invoking_event: String,
     /// A token that the function must pass to AWS Config with the PutEvaluations call
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "resultToken")]
@@ -87,7 +87,7 @@ pub struct ConfigEvent {
     #[serde(rename = "resultToken")]
     pub result_token: String,
     /// Key/value pairs that the function processes as part of its evaluation logic
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "ruleParameters")]
@@ -98,7 +98,7 @@ pub struct ConfigEvent {
     #[serde(default)]
     #[serde(rename = "ruleParameters")]
     pub rule_parameters: String,
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     pub version: Option<String>,

--- a/aws_lambda_events/src/generated/firehose.rs
+++ b/aws_lambda_events/src/generated/firehose.rs
@@ -4,7 +4,7 @@ use super::super::encodings::{Base64Data, MillisecondTimestamp};
 /// `KinesisFirehoseEvent` represents the input event from Amazon Kinesis Firehose. It is used as the input parameter.
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct KinesisFirehoseEvent {
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "invocationId")]
@@ -14,7 +14,7 @@ pub struct KinesisFirehoseEvent {
     #[serde(default)]
     #[serde(rename = "invocationId")]
     pub invocation_id: String,
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "deliveryStreamArn")]
@@ -24,7 +24,7 @@ pub struct KinesisFirehoseEvent {
     #[serde(default)]
     #[serde(rename = "deliveryStreamArn")]
     pub delivery_stream_arn: String,
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     pub region: Option<String>,
@@ -37,7 +37,7 @@ pub struct KinesisFirehoseEvent {
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct KinesisFirehoseEventRecord {
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "recordId")]

--- a/aws_lambda_events/src/generated/kinesis.rs
+++ b/aws_lambda_events/src/generated/kinesis.rs
@@ -9,7 +9,7 @@ pub struct KinesisEvent {
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct KinesisEventRecord {
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "awsRegion")]
@@ -19,7 +19,7 @@ pub struct KinesisEventRecord {
     #[serde(default)]
     #[serde(rename = "awsRegion")]
     pub aws_region: String,
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "eventID")]
@@ -29,7 +29,7 @@ pub struct KinesisEventRecord {
     #[serde(default)]
     #[serde(rename = "eventID")]
     pub event_id: String,
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "eventName")]
@@ -39,7 +39,7 @@ pub struct KinesisEventRecord {
     #[serde(default)]
     #[serde(rename = "eventName")]
     pub event_name: String,
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "eventSource")]
@@ -49,7 +49,7 @@ pub struct KinesisEventRecord {
     #[serde(default)]
     #[serde(rename = "eventSource")]
     pub event_source: String,
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "eventSourceARN")]
@@ -59,7 +59,7 @@ pub struct KinesisEventRecord {
     #[serde(default)]
     #[serde(rename = "eventSourceARN")]
     pub event_source_arn: String,
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "eventVersion")]
@@ -69,7 +69,7 @@ pub struct KinesisEventRecord {
     #[serde(default)]
     #[serde(rename = "eventVersion")]
     pub event_version: String,
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "invokeIdentityArn")]
@@ -89,7 +89,7 @@ pub struct KinesisRecord {
     pub data: Base64Data,
     #[serde(rename = "encryptionType")]
     pub encryption_type: Option<String>,
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "partitionKey")]
@@ -99,7 +99,7 @@ pub struct KinesisRecord {
     #[serde(default)]
     #[serde(rename = "partitionKey")]
     pub partition_key: String,
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "sequenceNumber")]
@@ -109,7 +109,7 @@ pub struct KinesisRecord {
     #[serde(default)]
     #[serde(rename = "sequenceNumber")]
     pub sequence_number: String,
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "kinesisSchemaVersion")]

--- a/aws_lambda_events/src/generated/s3.rs
+++ b/aws_lambda_events/src/generated/s3.rs
@@ -10,7 +10,7 @@ pub struct S3Event {
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct S3EventRecord {
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "eventVersion")]
@@ -20,7 +20,7 @@ pub struct S3EventRecord {
     #[serde(default)]
     #[serde(rename = "eventVersion")]
     pub event_version: String,
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "eventSource")]
@@ -30,7 +30,7 @@ pub struct S3EventRecord {
     #[serde(default)]
     #[serde(rename = "eventSource")]
     pub event_source: String,
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "awsRegion")]
@@ -42,7 +42,7 @@ pub struct S3EventRecord {
     pub aws_region: String,
     #[serde(rename = "eventTime")]
     pub event_time: DateTime<Utc>,
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "eventName")]
@@ -64,7 +64,7 @@ pub struct S3EventRecord {
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct S3UserIdentity {
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "principalId")]
@@ -78,7 +78,7 @@ pub struct S3UserIdentity {
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct S3RequestParameters {
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "sourceIPAddress")]
@@ -92,7 +92,7 @@ pub struct S3RequestParameters {
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct S3Entity {
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "s3SchemaVersion")]
@@ -102,7 +102,7 @@ pub struct S3Entity {
     #[serde(default)]
     #[serde(rename = "s3SchemaVersion")]
     pub schema_version: String,
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "configurationId")]
@@ -118,7 +118,7 @@ pub struct S3Entity {
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct S3Bucket {
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     pub name: Option<String>,
@@ -128,7 +128,7 @@ pub struct S3Bucket {
     pub name: String,
     #[serde(rename = "ownerIdentity")]
     pub owner_identity: S3UserIdentity,
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     pub arn: Option<String>,
@@ -140,7 +140,7 @@ pub struct S3Bucket {
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct S3Object {
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     pub key: Option<String>,
@@ -149,7 +149,7 @@ pub struct S3Object {
     #[serde(default)]
     pub key: String,
     pub size: i64,
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "urlDecodedKey")]
@@ -159,7 +159,7 @@ pub struct S3Object {
     #[serde(default)]
     #[serde(rename = "urlDecodedKey")]
     pub url_decoded_key: String,
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "versionId")]
@@ -169,7 +169,7 @@ pub struct S3Object {
     #[serde(default)]
     #[serde(rename = "versionId")]
     pub version_id: String,
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "eTag")]
@@ -179,7 +179,7 @@ pub struct S3Object {
     #[serde(default)]
     #[serde(rename = "eTag")]
     pub e_tag: String,
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     pub sequencer: Option<String>,

--- a/aws_lambda_events/src/generated/ses.rs
+++ b/aws_lambda_events/src/generated/ses.rs
@@ -10,7 +10,7 @@ pub struct SimpleEmailEvent {
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct SimpleEmailRecord {
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "eventVersion")]
@@ -20,7 +20,7 @@ pub struct SimpleEmailRecord {
     #[serde(default)]
     #[serde(rename = "eventVersion")]
     pub event_version: String,
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "eventSource")]
@@ -43,7 +43,7 @@ pub struct SimpleEmailService {
 pub struct SimpleEmailMessage {
     #[serde(rename = "commonHeaders")]
     pub common_headers: SimpleEmailCommonHeaders,
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     pub source: Option<String>,
@@ -56,7 +56,7 @@ pub struct SimpleEmailMessage {
     pub headers: Vec<SimpleEmailHeader>,
     #[serde(rename = "headersTruncated")]
     pub headers_truncated: bool,
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "messageId")]
@@ -87,7 +87,7 @@ pub struct SimpleEmailReceipt {
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct SimpleEmailHeader {
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     pub name: Option<String>,
@@ -95,7 +95,7 @@ pub struct SimpleEmailHeader {
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     pub name: String,
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     pub value: Option<String>,
@@ -109,7 +109,7 @@ pub struct SimpleEmailHeader {
 pub struct SimpleEmailCommonHeaders {
     pub from: Vec<String>,
     pub to: Vec<String>,
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "returnPath")]
@@ -119,7 +119,7 @@ pub struct SimpleEmailCommonHeaders {
     #[serde(default)]
     #[serde(rename = "returnPath")]
     pub return_path: String,
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "messageId")]
@@ -129,7 +129,7 @@ pub struct SimpleEmailCommonHeaders {
     #[serde(default)]
     #[serde(rename = "messageId")]
     pub message_id: String,
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     pub date: Option<String>,
@@ -137,7 +137,7 @@ pub struct SimpleEmailCommonHeaders {
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     pub date: String,
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     pub subject: Option<String>,
@@ -149,7 +149,7 @@ pub struct SimpleEmailCommonHeaders {
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct SimpleEmailReceiptAction {
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "type")]
@@ -159,7 +159,7 @@ pub struct SimpleEmailReceiptAction {
     #[serde(default)]
     #[serde(rename = "type")]
     pub type_: String,
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "invocationType")]
@@ -169,7 +169,7 @@ pub struct SimpleEmailReceiptAction {
     #[serde(default)]
     #[serde(rename = "invocationType")]
     pub invocation_type: String,
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "functionArn")]
@@ -183,7 +183,7 @@ pub struct SimpleEmailReceiptAction {
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct SimpleEmailVerdict {
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     pub status: Option<String>,

--- a/aws_lambda_events/src/generated/sns.rs
+++ b/aws_lambda_events/src/generated/sns.rs
@@ -11,7 +11,7 @@ pub struct SnsEvent {
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct SnsEventRecord {
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "EventVersion")]
@@ -21,7 +21,7 @@ pub struct SnsEventRecord {
     #[serde(default)]
     #[serde(rename = "EventVersion")]
     pub event_version: String,
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "EventSubscriptionArn")]
@@ -31,7 +31,7 @@ pub struct SnsEventRecord {
     #[serde(default)]
     #[serde(rename = "EventSubscriptionArn")]
     pub event_subscription_arn: String,
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "EventSource")]
@@ -47,7 +47,7 @@ pub struct SnsEventRecord {
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct SnsEntity {
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "Signature")]
@@ -57,7 +57,7 @@ pub struct SnsEntity {
     #[serde(default)]
     #[serde(rename = "Signature")]
     pub signature: String,
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "MessageId")]
@@ -67,7 +67,7 @@ pub struct SnsEntity {
     #[serde(default)]
     #[serde(rename = "MessageId")]
     pub message_id: String,
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "Type")]
@@ -77,7 +77,7 @@ pub struct SnsEntity {
     #[serde(default)]
     #[serde(rename = "Type")]
     pub type_: String,
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "TopicArn")]
@@ -90,7 +90,7 @@ pub struct SnsEntity {
     #[serde(deserialize_with = "deserialize_lambda_map")]
     #[serde(rename = "MessageAttributes")]
     pub message_attributes: HashMap<String, Value>,
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "SignatureVersion")]
@@ -102,7 +102,7 @@ pub struct SnsEntity {
     pub signature_version: String,
     #[serde(rename = "Timestamp")]
     pub timestamp: DateTime<Utc>,
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "SigningCertUrl")]
@@ -112,7 +112,7 @@ pub struct SnsEntity {
     #[serde(default)]
     #[serde(rename = "SigningCertUrl")]
     pub signing_cert_url: String,
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "Message")]
@@ -122,7 +122,7 @@ pub struct SnsEntity {
     #[serde(default)]
     #[serde(rename = "Message")]
     pub message: String,
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "UnsubscribeUrl")]
@@ -132,7 +132,7 @@ pub struct SnsEntity {
     #[serde(default)]
     #[serde(rename = "UnsubscribeUrl")]
     pub unsubscribe_url: String,
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "Subject")]

--- a/aws_lambda_events/src/generated/sqs.rs
+++ b/aws_lambda_events/src/generated/sqs.rs
@@ -10,7 +10,7 @@ pub struct SqsEvent {
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct SqsMessage {
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "messageId")]
@@ -20,7 +20,7 @@ pub struct SqsMessage {
     #[serde(default)]
     #[serde(rename = "messageId")]
     pub message_id: String,
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "receiptHandle")]
@@ -30,7 +30,7 @@ pub struct SqsMessage {
     #[serde(default)]
     #[serde(rename = "receiptHandle")]
     pub receipt_handle: String,
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     pub body: Option<String>,
@@ -38,7 +38,7 @@ pub struct SqsMessage {
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     pub body: String,
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "md5OfBody")]
@@ -48,7 +48,7 @@ pub struct SqsMessage {
     #[serde(default)]
     #[serde(rename = "md5OfBody")]
     pub md5_of_body: String,
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "md5OfMessageAttributes")]
@@ -63,7 +63,7 @@ pub struct SqsMessage {
     #[serde(deserialize_with = "deserialize_lambda_map")]
     #[serde(rename = "messageAttributes")]
     pub message_attributes: HashMap<String, SqsMessageAttribute>,
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "eventSourceARN")]
@@ -73,7 +73,7 @@ pub struct SqsMessage {
     #[serde(default)]
     #[serde(rename = "eventSourceARN")]
     pub event_source_arn: String,
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "eventSource")]
@@ -83,7 +83,7 @@ pub struct SqsMessage {
     #[serde(default)]
     #[serde(rename = "eventSource")]
     pub event_source: String,
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "awsRegion")]
@@ -105,7 +105,7 @@ pub struct SqsMessageAttribute {
     pub string_list_values: Vec<String>,
     #[serde(rename = "binaryListValues")]
     pub binary_list_values: Vec<Base64Data>,
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "dataType")]

--- a/aws_lambda_events_codegen/go_to_rust/src/lib.rs
+++ b/aws_lambda_events_codegen/go_to_rust/src/lib.rs
@@ -308,7 +308,7 @@ fn parse_struct(pairs: Pairs<Rule>) -> Result<(codegen::Struct, HashSet<String>)
 
             let mut string_as_option = Field::new(&member_name, "Option<String>");
             string_as_option.annotation(vec![
-                "#[cfg(feature = \"string-null-none\")]",
+                "#[cfg(not(feature = \"string-null-empty\"))]",
                 "#[serde(deserialize_with = \"deserialize_lambda_string\")]",
                 "#[serde(default)]",
             ]);

--- a/aws_lambda_events_codegen/go_to_rust/tests/fixtures/struct_members/expected.txt
+++ b/aws_lambda_events_codegen/go_to_rust/tests/fixtures/struct_members/expected.txt
@@ -8,7 +8,7 @@ use super::super::encodings::{Base64Data, MillisecondTimestamp, SecondTimestamp}
 pub struct SimpleEmailMessage {
     #[serde(rename = "commonHeaders")]
     pub common_headers: SimpleEmailCommonHeaders,
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     pub source: Option<String>,
@@ -23,7 +23,7 @@ pub struct SimpleEmailMessage {
     pub headers: Vec<SimpleEmailHeader>,
     #[serde(rename = "headersTruncated")]
     pub headers_truncated: bool,
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "messageId")]

--- a/aws_lambda_events_codegen/go_to_rust/tests/fixtures/struct_with_comments/expected.txt
+++ b/aws_lambda_events_codegen/go_to_rust/tests/fixtures/struct_with_comments/expected.txt
@@ -4,7 +4,7 @@ use custom_serde::*;
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct SimpleEmailEvent {
     /// My cool thing
-    #[cfg(feature = "string-null-none")]
+    #[cfg(not(feature = "string-null-empty"))]
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "fooBar")]


### PR DESCRIPTION
make it a bit easier to switch between `string-null-none` and `string-null-empty` styles. currently because the crate is a transitive dependency **default-feature** doesn't work as you might expect causing compiler issues if you try `string-null-empty`