### PR TITLE
Codegen type parameters for serde_json::Value fields

### DIFF
--- a/aws_lambda_events/src/generated/README.md
+++ b/aws_lambda_events/src/generated/README.md
@@ -3,4 +3,4 @@
 These types are automatically generated from the
 [official Go SDK](https://github.com/aws/aws-lambda-go/tree/master/events).
 
-Generated from commit [fa1a118928cc98dce34b990f0ab244dc13b1a8e6](https://github.com/aws/aws-lambda-go/commit/fa1a118928cc98dce34b990f0ab244dc13b1a8e6).
+Generated from commit [fb8f88d824489a878aee1e0badde7d8e129f8767](https://github.com/aws/aws-lambda-go/commit/fb8f88d824489a878aee1e0badde7d8e129f8767).

--- a/aws_lambda_events/src/generated/apigw.rs
+++ b/aws_lambda_events/src/generated/apigw.rs
@@ -1,5 +1,7 @@
 use custom_serde::*;
 use std::collections::HashMap;
+use serde::de::DeserializeOwned;
+use serde::ser::Serialize;
 use serde_json::Value;
 
 /// `ApiGatewayProxyRequest` contains data coming from the API Gateway proxy
@@ -59,7 +61,10 @@ pub struct ApiGatewayProxyResponse {
 /// `ApiGatewayProxyRequestContext` contains the information to identify the AWS account and resources invoking the
 /// Lambda function. It also includes Cognito identity information for the caller.
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
-pub struct ApiGatewayProxyRequestContext {
+pub struct ApiGatewayProxyRequestContext<T1=Value>
+where T1: DeserializeOwned,
+      T1: Serialize,
+{
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "accountId")]
@@ -82,7 +87,8 @@ pub struct ApiGatewayProxyRequestContext {
     pub resource_path: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_map")]
     #[serde(default)]
-    pub authorizer: HashMap<String, Value>,
+    #[serde(bound="")]
+    pub authorizer: HashMap<String, T1>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "httpMethod")]
@@ -263,7 +269,10 @@ pub struct ApiGatewayCustomAuthorizerRequestTypeRequest {
 
 /// `ApiGatewayCustomAuthorizerResponse` represents the expected format of an API Gateway authorization response.
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
-pub struct ApiGatewayCustomAuthorizerResponse {
+pub struct ApiGatewayCustomAuthorizerResponse<T1=Value>
+where T1: DeserializeOwned,
+      T1: Serialize,
+{
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "principalId")]
@@ -272,7 +281,8 @@ pub struct ApiGatewayCustomAuthorizerResponse {
     pub policy_document: ApiGatewayCustomAuthorizerPolicy,
     #[serde(deserialize_with = "deserialize_lambda_map")]
     #[serde(default)]
-    pub context: HashMap<String, Value>,
+    #[serde(bound="")]
+    pub context: HashMap<String, T1>,
     #[serde(rename = "usageIdentifierKey")]
     pub usage_identifier_key: Option<String>,
 }

--- a/aws_lambda_events/src/generated/appsync.rs
+++ b/aws_lambda_events/src/generated/appsync.rs
@@ -1,14 +1,20 @@
 use custom_serde::*;
+use serde::de::DeserializeOwned;
+use serde::ser::Serialize;
 use serde_json::Value;
 
 /// `AppSyncResolverTemplate` represents the requests from AppSync to Lambda
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
-pub struct AppSyncResolverTemplate {
+pub struct AppSyncResolverTemplate<T1=Value>
+where T1: DeserializeOwned,
+      T1: Serialize,
+{
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     pub version: Option<String>,
     pub operation: AppSyncOperation,
-    pub payload: Value,
+    #[serde(bound="")]
+    pub payload: T1,
 }
 
 pub type AppSyncOperation = String;

--- a/aws_lambda_events/src/generated/autoscaling.rs
+++ b/aws_lambda_events/src/generated/autoscaling.rs
@@ -1,11 +1,16 @@
 use chrono::{DateTime, Utc};
 use custom_serde::*;
+use serde::de::DeserializeOwned;
+use serde::ser::Serialize;
 use serde_json::Value;
 use std::collections::HashMap;
 
 /// `AutoScalingEvent` struct is used to parse the json for auto scaling event types //
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
-pub struct AutoScalingEvent {
+pub struct AutoScalingEvent<T1=Value>
+where T1: DeserializeOwned,
+      T1: Serialize,
+{
     /// The version of event data
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
@@ -38,5 +43,6 @@ pub struct AutoScalingEvent {
     pub resources: Vec<String>,
     #[serde(deserialize_with = "deserialize_lambda_map")]
     #[serde(default)]
-    pub detail: HashMap<String, Value>,
+    #[serde(bound="")]
+    pub detail: HashMap<String, T1>,
 }

--- a/aws_lambda_events/src/generated/cloudwatch_events.rs
+++ b/aws_lambda_events/src/generated/cloudwatch_events.rs
@@ -1,11 +1,16 @@
 use chrono::{DateTime, Utc};
 use custom_serde::*;
+use serde::de::DeserializeOwned;
+use serde::ser::Serialize;
 use serde_json::Value;
 
 /// `CloudWatchEvent` is the outer structure of an event sent via CloudWatch Events.
 /// For examples of events that come via CloudWatch Events, see https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/EventTypes.html
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
-pub struct CloudWatchEvent {
+pub struct CloudWatchEvent<T1=Value>
+where T1: DeserializeOwned,
+      T1: Serialize,
+{
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     pub version: Option<String>,
@@ -28,5 +33,6 @@ pub struct CloudWatchEvent {
     #[serde(default)]
     pub region: Option<String>,
     pub resources: Vec<String>,
-    pub detail: Value,
+    #[serde(bound="")]
+    pub detail: T1,
 }

--- a/aws_lambda_events/src/generated/sns.rs
+++ b/aws_lambda_events/src/generated/sns.rs
@@ -1,5 +1,7 @@
 use custom_serde::*;
 use chrono::{DateTime, Utc};
+use serde::de::DeserializeOwned;
+use serde::ser::Serialize;
 use serde_json::Value;
 use std::collections::HashMap;
 
@@ -28,7 +30,10 @@ pub struct SnsEventRecord {
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
-pub struct SnsEntity {
+pub struct SnsEntity<T1=Value>
+where T1: DeserializeOwned,
+      T1: Serialize,
+{
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "Signature")]
@@ -47,8 +52,9 @@ pub struct SnsEntity {
     pub topic_arn: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_map")]
     #[serde(default)]
+    #[serde(bound="")]
     #[serde(rename = "MessageAttributes")]
-    pub message_attributes: HashMap<String, Value>,
+    pub message_attributes: HashMap<String, T1>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "SignatureVersion")]


### PR DESCRIPTION
This allows callers to provide a struct type for the CloudWatchEvent `detail` field and have it automatically deserialised by the runtime.

As an example, here is the skeleton of a lambda I built to receive CloudWatch Events for STS AssumeRole. Previously you’d write this:

```
lambda::start(|input: CloudWatchEvent| {
    let assume_role: AssumeRoleDetail = serde_json::value::from_value(input.detail)?;

    ...
})
```

Now you can write:

```
lambda::start(|input: CloudWatchEvent<AssumeRoleDetail>| {
    ...
})
```

I don’t know of any authoritative source for the detail payloads that we could use to codegen them, but this will let you sub in a specific event in place of the `serde_json::Value` field type.

Fixes https://github.com/srijs/rust-aws-lambda/issues/10

<details>
<summary>struct types for example</summary>

```
#[derive(Deserialize, Serialize, Debug)]
struct UserIdentity {
    arn: String,
    #[serde(rename="userName")]
    user_name: String,
}

#[derive(Deserialize, Serialize, Debug)]
struct RequestParameters {
    #[serde(rename="roleArn")]
    role_arn: String,
}

#[derive(Deserialize, Serialize, Debug)]
struct AssumeRoleDetail {
    #[serde(rename="userIdentity")]
    user_identity: UserIdentity,
    #[serde(rename="requestParameters")]
    request_parameters: RequestParameters,
}
```

</details>